### PR TITLE
Add checkbox for attaching files to emails

### DIFF
--- a/src/NzbDrone.Core/Notifications/Boxcar/Boxcar.cs
+++ b/src/NzbDrone.Core/Notifications/Boxcar/Boxcar.cs
@@ -18,12 +18,12 @@ namespace NzbDrone.Core.Notifications.Boxcar
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            _proxy.SendNotification(ALBUM_GRABBED_TITLE, grabMessage.Message, Settings);
+            _proxy.SendNotification(BOOK_GRABBED_TITLE, grabMessage.Message, Settings);
         }
 
         public override void OnReleaseImport(AlbumDownloadMessage message)
         {
-            _proxy.SendNotification(ALBUM_DOWNLOADED_TITLE, message.Message, Settings);
+            _proxy.SendNotification(BOOK_DOWNLOADED_TITLE, message.Message, Settings);
         }
 
         public override void OnHealthIssue(HealthCheck.HealthCheck message)

--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -92,7 +92,7 @@ namespace NzbDrone.Core.Notifications.Discord
                               {
                                   new Embed
                                   {
-                                      Title = TRACK_RETAGGED_TITLE,
+                                      Title = BOOK_RETAGGED_TITLE,
                                       Text = message.Message
                                   }
                               };

--- a/src/NzbDrone.Core/Notifications/Email/Email.cs
+++ b/src/NzbDrone.Core/Notifications/Email/Email.cs
@@ -28,7 +28,9 @@ namespace NzbDrone.Core.Notifications.Email
         {
             var body = $"{message.Message} Downloaded and sorted.";
 
-            _emailService.SendEmail(Settings, ALBUM_DOWNLOADED_TITLE_BRANDED, body);
+            var paths = Settings.AttachFiles ? message.TrackFiles.SelectList(a => a.Path) : null;
+
+            _emailService.SendEmail(Settings, ALBUM_DOWNLOADED_TITLE_BRANDED, body, false, paths);
         }
 
         public override void OnHealthIssue(HealthCheck.HealthCheck message)

--- a/src/NzbDrone.Core/Notifications/Email/Email.cs
+++ b/src/NzbDrone.Core/Notifications/Email/Email.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Notifications.Email
         {
             var body = $"{grabMessage.Message} sent to queue.";
 
-            _emailService.SendEmail(Settings, ALBUM_GRABBED_TITLE_BRANDED, body);
+            _emailService.SendEmail(Settings, BOOK_GRABBED_TITLE_BRANDED, body);
         }
 
         public override void OnReleaseImport(AlbumDownloadMessage message)
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Notifications.Email
 
             var paths = Settings.AttachFiles ? message.TrackFiles.SelectList(a => a.Path) : null;
 
-            _emailService.SendEmail(Settings, ALBUM_DOWNLOADED_TITLE_BRANDED, body, false, paths);
+            _emailService.SendEmail(Settings, BOOK_DOWNLOADED_TITLE_BRANDED, body, false, paths);
         }
 
         public override void OnHealthIssue(HealthCheck.HealthCheck message)

--- a/src/NzbDrone.Core/Notifications/Email/EmailService.cs
+++ b/src/NzbDrone.Core/Notifications/Email/EmailService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Mail;
 using FluentValidation.Results;
@@ -8,7 +9,7 @@ namespace NzbDrone.Core.Notifications.Email
 {
     public interface IEmailService
     {
-        void SendEmail(EmailSettings settings, string subject, string body, bool htmlBody = false);
+        void SendEmail(EmailSettings settings, string subject, string body, bool htmlBody = false, List<string> attachmentUrls = null);
         ValidationFailure Test(EmailSettings settings);
     }
 
@@ -21,7 +22,7 @@ namespace NzbDrone.Core.Notifications.Email
             _logger = logger;
         }
 
-        public void SendEmail(EmailSettings settings, string subject, string body, bool htmlBody = false)
+        public void SendEmail(EmailSettings settings, string subject, string body, bool htmlBody = false, List<string> attachmentUrls = null)
         {
             var email = new MailMessage();
             email.From = new MailAddress(settings.From);
@@ -31,6 +32,14 @@ namespace NzbDrone.Core.Notifications.Email
             email.Subject = subject;
             email.Body = body;
             email.IsBodyHtml = htmlBody;
+
+            if (attachmentUrls != null)
+            {
+                foreach (var url in attachmentUrls)
+                {
+                    email.Attachments.Add(new Attachment(url));
+                }
+            }
 
             NetworkCredential credentials = null;
 

--- a/src/NzbDrone.Core/Notifications/Email/EmailService.cs
+++ b/src/NzbDrone.Core/Notifications/Email/EmailService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Mail;
 using FluentValidation.Results;
@@ -27,7 +28,9 @@ namespace NzbDrone.Core.Notifications.Email
             var email = new MailMessage();
             email.From = new MailAddress(settings.From);
 
-            email.To.Add(settings.To);
+            settings.To.ToList().ForEach(x => email.To.Add(x));
+            settings.CC.ToList().ForEach(x => email.CC.Add(x));
+            settings.Bcc.ToList().ForEach(x => email.Bcc.Add(x));
 
             email.Subject = subject;
             email.Body = body;

--- a/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
@@ -23,6 +24,10 @@ namespace NzbDrone.Core.Notifications.Email
         public EmailSettings()
         {
             Port = 25;
+
+            To = new string[] { };
+            CC = new string[] { };
+            Bcc = new string[] { };
         }
 
         [FieldDefinition(0, Label = "Server", HelpText = "Hostname or IP of Email server")]
@@ -43,10 +48,16 @@ namespace NzbDrone.Core.Notifications.Email
         [FieldDefinition(5, Label = "From Address")]
         public string From { get; set; }
 
-        [FieldDefinition(6, Label = "Recipient Address")]
-        public string To { get; set; }
+        [FieldDefinition(6, Label = "Recipient Address(es)", HelpText = "Comma seperated list of email recipients")]
+        public IEnumerable<string> To { get; set; }
 
-        [FieldDefinition(7, Label = "Attach Books", HelpText = "Add books as an attachment on import", Type = FieldType.Checkbox)]
+        [FieldDefinition(7, Label = "CC Address(es)", HelpText = "Comma seperated list of email cc recipients", Advanced = true)]
+        public IEnumerable<string> CC { get; set; }
+
+        [FieldDefinition(8, Label = "BCC Address(es)", HelpText = "Comma seperated list of email bcc recipients", Advanced = true)]
+        public IEnumerable<string> Bcc { get; set; }
+
+        [FieldDefinition(9, Label = "Attach Books", HelpText = "Add books as an attachment on import", Type = FieldType.Checkbox)]
         public bool AttachFiles { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation;
+using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
@@ -45,6 +45,9 @@ namespace NzbDrone.Core.Notifications.Email
 
         [FieldDefinition(6, Label = "Recipient Address")]
         public string To { get; set; }
+
+        [FieldDefinition(7, Label = "Attach Books", HelpText = "Add books as an attachment on import", Type = FieldType.Checkbox)]
+        public bool AttachFiles { get; set; }
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Notifications/Gotify/Gotify.cs
+++ b/src/NzbDrone.Core/Notifications/Gotify/Gotify.cs
@@ -21,12 +21,12 @@ namespace NzbDrone.Core.Notifications.Gotify
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            _proxy.SendNotification(ALBUM_GRABBED_TITLE, grabMessage.Message, Settings);
+            _proxy.SendNotification(BOOK_GRABBED_TITLE, grabMessage.Message, Settings);
         }
 
         public override void OnReleaseImport(AlbumDownloadMessage message)
         {
-            _proxy.SendNotification(ALBUM_DOWNLOADED_TITLE, message.Message, Settings);
+            _proxy.SendNotification(BOOK_DOWNLOADED_TITLE, message.Message, Settings);
         }
 
         public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)

--- a/src/NzbDrone.Core/Notifications/Join/Join.cs
+++ b/src/NzbDrone.Core/Notifications/Join/Join.cs
@@ -19,12 +19,12 @@ namespace NzbDrone.Core.Notifications.Join
 
         public override void OnGrab(GrabMessage message)
         {
-            _proxy.SendNotification(ALBUM_GRABBED_TITLE_BRANDED, message.Message, Settings);
+            _proxy.SendNotification(BOOK_GRABBED_TITLE_BRANDED, message.Message, Settings);
         }
 
         public override void OnReleaseImport(AlbumDownloadMessage message)
         {
-            _proxy.SendNotification(ALBUM_DOWNLOADED_TITLE_BRANDED, message.Message, Settings);
+            _proxy.SendNotification(BOOK_DOWNLOADED_TITLE_BRANDED, message.Message, Settings);
         }
 
         public override void OnHealthIssue(HealthCheck.HealthCheck message)

--- a/src/NzbDrone.Core/Notifications/NotificationBase.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationBase.cs
@@ -9,12 +9,12 @@ namespace NzbDrone.Core.Notifications
     public abstract class NotificationBase<TSettings> : INotification
         where TSettings : IProviderConfig, new()
     {
-        protected const string ALBUM_GRABBED_TITLE = "Album Grabbed";
-        protected const string ALBUM_DOWNLOADED_TITLE = "Album Downloaded";
+        protected const string ALBUM_GRABBED_TITLE = "Book Grabbed";
+        protected const string ALBUM_DOWNLOADED_TITLE = "Book Downloaded";
         protected const string HEALTH_ISSUE_TITLE = "Health Check Failure";
         protected const string DOWNLOAD_FAILURE_TITLE = "Download Failed";
         protected const string IMPORT_FAILURE_TITLE = "Import Failed";
-        protected const string TRACK_RETAGGED_TITLE = "Track File Tags Updated";
+        protected const string TRACK_RETAGGED_TITLE = "Book File Tags Updated";
 
         protected const string ALBUM_GRABBED_TITLE_BRANDED = "Readarr - " + ALBUM_GRABBED_TITLE;
         protected const string ALBUM_DOWNLOADED_TITLE_BRANDED = "Readarr - " + ALBUM_DOWNLOADED_TITLE;

--- a/src/NzbDrone.Core/Notifications/NotificationBase.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationBase.cs
@@ -9,19 +9,19 @@ namespace NzbDrone.Core.Notifications
     public abstract class NotificationBase<TSettings> : INotification
         where TSettings : IProviderConfig, new()
     {
-        protected const string ALBUM_GRABBED_TITLE = "Book Grabbed";
-        protected const string ALBUM_DOWNLOADED_TITLE = "Book Downloaded";
+        protected const string BOOK_GRABBED_TITLE = "Book Grabbed";
+        protected const string BOOK_DOWNLOADED_TITLE = "Book Downloaded";
         protected const string HEALTH_ISSUE_TITLE = "Health Check Failure";
         protected const string DOWNLOAD_FAILURE_TITLE = "Download Failed";
         protected const string IMPORT_FAILURE_TITLE = "Import Failed";
-        protected const string TRACK_RETAGGED_TITLE = "Book File Tags Updated";
+        protected const string BOOK_RETAGGED_TITLE = "Book File Tags Updated";
 
-        protected const string ALBUM_GRABBED_TITLE_BRANDED = "Readarr - " + ALBUM_GRABBED_TITLE;
-        protected const string ALBUM_DOWNLOADED_TITLE_BRANDED = "Readarr - " + ALBUM_DOWNLOADED_TITLE;
+        protected const string BOOK_GRABBED_TITLE_BRANDED = "Readarr - " + BOOK_GRABBED_TITLE;
+        protected const string BOOK_DOWNLOADED_TITLE_BRANDED = "Readarr - " + BOOK_DOWNLOADED_TITLE;
         protected const string HEALTH_ISSUE_TITLE_BRANDED = "Readarr - " + HEALTH_ISSUE_TITLE;
         protected const string DOWNLOAD_FAILURE_TITLE_BRANDED = "Readarr - " + DOWNLOAD_FAILURE_TITLE;
         protected const string IMPORT_FAILURE_TITLE_BRANDED = "Readarr - " + IMPORT_FAILURE_TITLE;
-        protected const string TRACK_RETAGGED_TITLE_BRANDED = "Readarr - " + TRACK_RETAGGED_TITLE;
+        protected const string BOOK_RETAGGED_TITLE_BRANDED = "Readarr - " + BOOK_RETAGGED_TITLE;
 
         public abstract string Name { get; }
 

--- a/src/NzbDrone.Core/Notifications/PushBullet/PushBullet.cs
+++ b/src/NzbDrone.Core/Notifications/PushBullet/PushBullet.cs
@@ -21,12 +21,12 @@ namespace NzbDrone.Core.Notifications.PushBullet
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            _proxy.SendNotification(ALBUM_GRABBED_TITLE_BRANDED, grabMessage.Message, Settings);
+            _proxy.SendNotification(BOOK_GRABBED_TITLE_BRANDED, grabMessage.Message, Settings);
         }
 
         public override void OnReleaseImport(AlbumDownloadMessage message)
         {
-            _proxy.SendNotification(ALBUM_DOWNLOADED_TITLE_BRANDED, message.Message, Settings);
+            _proxy.SendNotification(BOOK_DOWNLOADED_TITLE_BRANDED, message.Message, Settings);
         }
 
         public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)

--- a/src/NzbDrone.Core/Notifications/Pushover/Pushover.cs
+++ b/src/NzbDrone.Core/Notifications/Pushover/Pushover.cs
@@ -18,12 +18,12 @@ namespace NzbDrone.Core.Notifications.Pushover
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            _proxy.SendNotification(ALBUM_GRABBED_TITLE, grabMessage.Message, Settings);
+            _proxy.SendNotification(BOOK_GRABBED_TITLE, grabMessage.Message, Settings);
         }
 
         public override void OnReleaseImport(AlbumDownloadMessage message)
         {
-            _proxy.SendNotification(ALBUM_DOWNLOADED_TITLE, message.Message, Settings);
+            _proxy.SendNotification(BOOK_DOWNLOADED_TITLE, message.Message, Settings);
         }
 
         public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)

--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -92,12 +92,12 @@ namespace NzbDrone.Core.Notifications.Slack
                               {
                                   new Attachment
                                   {
-                                      Title = TRACK_RETAGGED_TITLE,
+                                      Title = BOOK_RETAGGED_TITLE,
                                       Text = message.Message
                                   }
                               };
 
-            var payload = CreatePayload(TRACK_RETAGGED_TITLE, attachments);
+            var payload = CreatePayload(BOOK_RETAGGED_TITLE, attachments);
 
             _proxy.SendPayload(payload, Settings);
         }

--- a/src/NzbDrone.Core/Notifications/Subsonic/Subsonic.cs
+++ b/src/NzbDrone.Core/Notifications/Subsonic/Subsonic.cs
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.Notifications.Subsonic
 
         public override void OnTrackRetag(TrackRetagMessage message)
         {
-            Notify(Settings, TRACK_RETAGGED_TITLE_BRANDED, message.Message);
+            Notify(Settings, BOOK_RETAGGED_TITLE_BRANDED, message.Message);
         }
 
         public override string Name => "Subsonic";

--- a/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
@@ -18,12 +18,12 @@ namespace NzbDrone.Core.Notifications.Telegram
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            _proxy.SendNotification(ALBUM_GRABBED_TITLE, grabMessage.Message, Settings);
+            _proxy.SendNotification(BOOK_GRABBED_TITLE, grabMessage.Message, Settings);
         }
 
         public override void OnReleaseImport(AlbumDownloadMessage message)
         {
-            _proxy.SendNotification(ALBUM_DOWNLOADED_TITLE, message.Message, Settings);
+            _proxy.SendNotification(BOOK_DOWNLOADED_TITLE, message.Message, Settings);
         }
 
         public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Added a flag to the email notification/connection that allows the user to attach files to the email that's sent out on successful import, useful for sending to your Kindle email address.

Also renamed the subjects on the emails

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* 
