### PR TITLE
Use optional chaining to access errors property

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/Naming.js
+++ b/frontend/src/Settings/MediaManagement/Naming/Naming.js
@@ -167,7 +167,7 @@ class Naming extends Component {
                   onChange={onInputChange}
                   {...settings.authorFolderFormat}
                   helpTexts={['Used when adding a new artist or moving an author via the author editor', ...authorFolderFormatHelpTexts]}
-                  errors={[...authorFolderFormatErrors, ...settings.authorFolderFormat.errors]}
+                  errors={[...authorFolderFormatErrors, ...settings.authorFolderFormat?.errors]}
                 />
               </FormGroup>
 


### PR DESCRIPTION
#### Database Migration
No

#### Description
Fix issue accessing nested property on the `/mediamanagement` view.
![image](https://user-images.githubusercontent.com/1173849/81892120-24cbf700-955f-11ea-9bd2-dbe79f359d37.png)

#### Todos
N/A
#### Issues Fixed or Closed by this PR

* 
