### PR TITLE
Fix author manual import

### DIFF
--- a/frontend/src/Author/Details/AuthorDetails.js
+++ b/frontend/src/Author/Details/AuthorDetails.js
@@ -676,6 +676,7 @@ class AuthorDetails extends Component {
 
           <InteractiveImportModal
             isOpen={isInteractiveImportModalOpen}
+            authorId={id}
             folder={path}
             allowAuthorChange={false}
             showFilterExistingFiles={true}

--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.js
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.js
@@ -408,7 +408,7 @@ class InteractiveImportModalContent extends Component {
 
           {
             isPopulated && !items.length && !isFetching &&
-              'No audio files were found in the selected folder'
+              'No book files were found in the selected folder'
           }
         </ModalBody>
 

--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContentConnector.js
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContentConnector.js
@@ -52,6 +52,7 @@ class InteractiveImportModalContentConnector extends Component {
 
   componentDidMount() {
     const {
+      authorId,
       downloadId,
       folder
     } = this.props;
@@ -62,6 +63,7 @@ class InteractiveImportModalContentConnector extends Component {
     } = this.state;
 
     this.props.fetchInteractiveImportItems({
+      authorId,
       downloadId,
       folder,
       filterExistingFiles,
@@ -78,11 +80,13 @@ class InteractiveImportModalContentConnector extends Component {
     if (prevState.filterExistingFiles !== filterExistingFiles ||
         prevState.replaceExistingFiles !== replaceExistingFiles) {
       const {
+        authorId,
         downloadId,
         folder
       } = this.props;
 
       this.props.fetchInteractiveImportItems({
+        authorId,
         downloadId,
         folder,
         filterExistingFiles,
@@ -195,6 +199,7 @@ class InteractiveImportModalContentConnector extends Component {
 }
 
 InteractiveImportModalContentConnector.propTypes = {
+  authorId: PropTypes.number,
   downloadId: PropTypes.string,
   folder: PropTypes.string,
   filterExistingFiles: PropTypes.bool.isRequired,
@@ -210,6 +215,7 @@ InteractiveImportModalContentConnector.propTypes = {
 };
 
 InteractiveImportModalContentConnector.defaultProps = {
+  authorId: 0,
   filterExistingFiles: true,
   replaceExistingFiles: false
 };

--- a/src/NzbDrone.Core/MediaFiles/BookImport/Identification/CandidateService.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/Identification/CandidateService.cs
@@ -60,16 +60,16 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Identification
             //         tagCandidate = GetDbCandidatesByRelease(new List<AlbumRelease> { tagMbidRelease }, includeExisting);
             //     }
             // }
-            if (idOverrides?.Album != null)
+            if (idOverrides?.Book != null)
             {
                 // use the release from file tags if it exists and agrees with the specified book
-                if (tagMbidRelease?.Id == idOverrides.Album.Id)
+                if (tagMbidRelease?.Id == idOverrides.Book.Id)
                 {
                     candidateReleases = tagCandidate;
                 }
                 else
                 {
-                    candidateReleases = GetDbCandidatesByAlbum(idOverrides.Album, includeExisting);
+                    candidateReleases = GetDbCandidatesByAlbum(idOverrides.Book, includeExisting);
                 }
             }
             else if (idOverrides?.Author != null)

--- a/src/NzbDrone.Core/MediaFiles/BookImport/Identification/IdentificationService.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/Identification/IdentificationService.cs
@@ -129,7 +129,7 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Identification
                 // populate the overrides and return
                 foreach (var localTrack in localAlbumRelease.LocalBooks)
                 {
-                    localTrack.Book = idOverrides.Album;
+                    localTrack.Book = idOverrides.Book;
                     localTrack.Author = idOverrides.Author;
                 }
 

--- a/src/NzbDrone.Core/MediaFiles/BookImport/Identification/IdentificationService.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/Identification/IdentificationService.cs
@@ -125,6 +125,14 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Identification
 
             if (candidateReleases.Count == 0)
             {
+                // can't find any candidates even after fingerprinting
+                // populate the overrides and return
+                foreach (var localTrack in localAlbumRelease.LocalBooks)
+                {
+                    localTrack.Book = idOverrides.Album;
+                    localTrack.Author = idOverrides.Author;
+                }
+
                 return;
             }
 

--- a/src/NzbDrone.Core/MediaFiles/BookImport/ImportDecisionMaker.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/ImportDecisionMaker.cs
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.MediaFiles.BookImport
     public class IdentificationOverrides
     {
         public Author Author { get; set; }
-        public Book Album { get; set; }
+        public Book Book { get; set; }
     }
 
     public class ImportDecisionMakerInfo

--- a/src/NzbDrone.Core/MediaFiles/BookImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/Manual/ManualImportService.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Manual
 {
     public interface IManualImportService
     {
-        List<ManualImportItem> GetMediaFiles(string path, string downloadId, FilterFilesType filter, bool replaceExistingFiles);
+        List<ManualImportItem> GetMediaFiles(string path, string downloadId, Author author, FilterFilesType filter, bool replaceExistingFiles);
         List<ManualImportItem> UpdateItems(List<ManualImportItem> item);
     }
 
@@ -72,7 +72,7 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Manual
             _logger = logger;
         }
 
-        public List<ManualImportItem> GetMediaFiles(string path, string downloadId, FilterFilesType filter, bool replaceExistingFiles)
+        public List<ManualImportItem> GetMediaFiles(string path, string downloadId, Author author, FilterFilesType filter, bool replaceExistingFiles)
         {
             if (downloadId.IsNotNullOrWhiteSpace())
             {
@@ -110,14 +110,14 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Manual
                 return new List<ManualImportItem> { result };
             }
 
-            return ProcessFolder(path, downloadId, filter, replaceExistingFiles);
+            return ProcessFolder(path, downloadId, author, filter, replaceExistingFiles);
         }
 
-        private List<ManualImportItem> ProcessFolder(string folder, string downloadId, FilterFilesType filter, bool replaceExistingFiles)
+        private List<ManualImportItem> ProcessFolder(string folder, string downloadId, Author author, FilterFilesType filter, bool replaceExistingFiles)
         {
             DownloadClientItem downloadClientItem = null;
             var directoryInfo = new DirectoryInfo(folder);
-            var author = _parsingService.GetArtist(directoryInfo.Name);
+            author = author ?? _parsingService.GetArtist(directoryInfo.Name);
 
             if (downloadId.IsNotNullOrWhiteSpace())
             {

--- a/src/NzbDrone.Core/MediaFiles/BookImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/Manual/ManualImportService.cs
@@ -181,7 +181,7 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Manual
                 var idOverride = new IdentificationOverrides
                 {
                     Author = group.First().Author,
-                    Album = group.First().Book,
+                    Book = group.First().Book,
                 };
                 var config = new ImportDecisionMakerConfig
                 {

--- a/src/Readarr.Api.V1/ManualImport/ManualImportModule.cs
+++ b/src/Readarr.Api.V1/ManualImport/ManualImportModule.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Nancy;
@@ -41,10 +42,23 @@ namespace Readarr.Api.V1.ManualImport
         {
             var folder = (string)Request.Query.folder;
             var downloadId = (string)Request.Query.downloadId;
+            NzbDrone.Core.Books.Author author = null;
+
+            var authorIdQuery = Request.Query.authorId;
+            if (authorIdQuery.HasValue)
+            {
+                var authorId = Convert.ToInt32(authorIdQuery.Value);
+
+                if (authorId > 0)
+                {
+                    author = _authorService.GetAuthor(authorId);
+                }
+            }
+
             var filter = Request.GetBooleanQueryParameter("filterExistingFiles", true) ? FilterFilesType.Matched : FilterFilesType.None;
             var replaceExistingFiles = Request.GetBooleanQueryParameter("replaceExistingFiles", true);
 
-            return _manualImportService.GetMediaFiles(folder, downloadId, filter, replaceExistingFiles).ToResource().Select(AddQualityWeight).ToList();
+            return _manualImportService.GetMediaFiles(folder, downloadId, author, filter, replaceExistingFiles).ToResource().Select(AddQualityWeight).ToList();
         }
 
         private ManualImportResource AddQualityWeight(ManualImportResource item)


### PR DESCRIPTION
#### Database Migration
 NO

#### Description
When importing files in the author view, if the file can't be identified then it's left empty and the book can't be selected.

Also fixed is the empty message when no files are found, used to say "audio files"

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

Reported via Discord by Tom
