### PR TITLE
New: Support digest auth for calibre, add calibre healthcheck

### DIFF
--- a/src/NzbDrone.Common/Http/BasicNetworkCredential.cs
+++ b/src/NzbDrone.Common/Http/BasicNetworkCredential.cs
@@ -1,0 +1,12 @@
+using System.Net;
+
+namespace NzbDrone.Common.Http
+{
+    public class BasicNetworkCredential : NetworkCredential
+    {
+        public BasicNetworkCredential(string user, string pass)
+        : base(user, pass)
+        {
+        }
+    }
+}

--- a/src/NzbDrone.Common/Http/HttpRequest.cs
+++ b/src/NzbDrone.Common/Http/HttpRequest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Text;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
@@ -33,6 +34,7 @@ namespace NzbDrone.Common.Http
         public HttpHeader Headers { get; set; }
         public byte[] ContentData { get; set; }
         public string ContentSummary { get; set; }
+        public ICredentials Credentials { get; set; }
         public bool SuppressHttpError { get; set; }
         public bool UseSimplifiedUserAgent { get; set; }
         public bool AllowAutoRedirect { get; set; }
@@ -79,13 +81,6 @@ namespace NzbDrone.Common.Http
         {
             var encoding = HttpHeader.GetEncodingFromContentType(Headers.ContentType);
             ContentData = encoding.GetBytes(data);
-        }
-
-        public void AddBasicAuthentication(string username, string password)
-        {
-            var authInfo = Convert.ToBase64String(Encoding.GetEncoding("ISO-8859-1").GetBytes($"{username}:{password}"));
-
-            Headers.Set("Authorization", "Basic " + authInfo);
         }
     }
 }

--- a/src/NzbDrone.Common/Http/HttpRequestBuilder.cs
+++ b/src/NzbDrone.Common/Http/HttpRequestBuilder.cs
@@ -24,10 +24,9 @@ namespace NzbDrone.Common.Http
         public bool ConnectionKeepAlive { get; set; }
         public TimeSpan RateLimit { get; set; }
         public bool LogResponseContent { get; set; }
-        public NetworkCredential NetworkCredential { get; set; }
+        public ICredentials NetworkCredential { get; set; }
         public Dictionary<string, string> Cookies { get; private set; }
         public List<HttpFormData> FormData { get; private set; }
-
         public Action<HttpRequest> PostProcess { get; set; }
 
         public HttpRequestBuilder(string baseUrl)
@@ -105,13 +104,7 @@ namespace NzbDrone.Common.Http
             request.ConnectionKeepAlive = ConnectionKeepAlive;
             request.RateLimit = RateLimit;
             request.LogResponseContent = LogResponseContent;
-
-            if (NetworkCredential != null)
-            {
-                var authInfo = NetworkCredential.UserName + ":" + NetworkCredential.Password;
-                authInfo = Convert.ToBase64String(Encoding.GetEncoding("ISO-8859-1").GetBytes(authInfo));
-                request.Headers.Set("Authorization", "Basic " + authInfo);
-            }
+            request.Credentials = NetworkCredential;
 
             foreach (var header in Headers)
             {

--- a/src/NzbDrone.Common/Http/Proxy/ManagedWebProxyFactory.cs
+++ b/src/NzbDrone.Common/Http/Proxy/ManagedWebProxyFactory.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Common.Http.Proxy
                 case ProxyType.Http:
                     if (proxySettings.Username.IsNotNullOrWhiteSpace() && proxySettings.Password.IsNotNullOrWhiteSpace())
                     {
-                        return new WebProxy(proxySettings.Host + ":" + proxySettings.Port, proxySettings.BypassLocalAddress, proxySettings.BypassListAsArray, new NetworkCredential(proxySettings.Username, proxySettings.Password));
+                        return new WebProxy(proxySettings.Host + ":" + proxySettings.Port, proxySettings.BypassLocalAddress, proxySettings.BypassListAsArray, new BasicNetworkCredential(proxySettings.Username, proxySettings.Password));
                     }
                     else
                     {

--- a/src/NzbDrone.Core/Books/Calibre/CalibreProxy.cs
+++ b/src/NzbDrone.Core/Books/Calibre/CalibreProxy.cs
@@ -13,7 +13,6 @@ using NzbDrone.Common.Serializer;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.RemotePathMappings;
-using NzbDrone.Core.Rest;
 
 namespace NzbDrone.Core.Books.Calibre
 {
@@ -70,7 +69,7 @@ namespace NzbDrone.Core.Books.Calibre
 
                 return _httpClient.Post<CalibreImportJob>(request).Resource;
             }
-            catch (RestException ex)
+            catch (HttpException ex)
             {
                 throw new CalibreException("Unable to add file to calibre library: {0}", ex, ex.Message);
             }
@@ -177,7 +176,7 @@ namespace NzbDrone.Core.Books.Calibre
 
                 return _httpClient.Get<CalibreBookData>(request).Resource;
             }
-            catch (RestException ex)
+            catch (HttpException ex)
             {
                 throw new CalibreException("Unable to add file to calibre library: {0}", ex, ex.Message);
             }
@@ -199,7 +198,7 @@ namespace NzbDrone.Core.Books.Calibre
 
                 return jobId;
             }
-            catch (RestException ex)
+            catch (HttpException ex)
             {
                 throw new CalibreException("Unable to start calibre conversion: {0}", ex, ex.Message);
             }
@@ -221,7 +220,7 @@ namespace NzbDrone.Core.Books.Calibre
 
                 return book;
             }
-            catch (RestException ex)
+            catch (HttpException ex)
             {
                 throw new CalibreException("Unable to connect to calibre library: {0}", ex, ex.Message);
             }
@@ -256,7 +255,7 @@ namespace NzbDrone.Core.Books.Calibre
 
                 return result;
             }
-            catch (RestException ex)
+            catch (HttpException ex)
             {
                 throw new CalibreException("Unable to connect to calibre library: {0}", ex, ex.Message);
             }
@@ -270,7 +269,7 @@ namespace NzbDrone.Core.Books.Calibre
                 var request = builder.Build();
                 var response = _httpClient.Execute(request);
             }
-            catch (RestException ex)
+            catch (HttpException ex)
             {
                 throw new CalibreException("Unable to connect to calibre library: {0}", ex, ex.Message);
             }

--- a/src/NzbDrone.Core/Books/Calibre/CalibreSettings.cs
+++ b/src/NzbDrone.Core/Books/Calibre/CalibreSettings.cs
@@ -2,8 +2,7 @@ using System;
 using System.Linq;
 using FluentValidation;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Books.Calibre
@@ -23,7 +22,7 @@ namespace NzbDrone.Core.Books.Calibre
         }
     }
 
-    public class CalibreSettings : IProviderConfig
+    public class CalibreSettings : IEmbeddedDocument
     {
         private static readonly CalibreSettingsValidator Validator = new CalibreSettingsValidator();
 
@@ -32,28 +31,13 @@ namespace NzbDrone.Core.Books.Calibre
             Port = 8080;
         }
 
-        [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox)]
         public string Host { get; set; }
-
-        [FieldDefinition(1, Label = "Port", Type = FieldType.Textbox)]
-        public int Port { get; set; }
-
-        [FieldDefinition(2, Label = "Url Base", Type = FieldType.Textbox, Advanced = true, HelpText = "Adds a prefix to the calibre url, e.g. http://[host]:[port]/[urlBase]")]
+        public int Port { get; set; } = 8080;
         public string UrlBase { get; set; }
-
-        [FieldDefinition(3, Label = "Username", Type = FieldType.Textbox)]
         public string Username { get; set; }
-
-        [FieldDefinition(4, Label = "Password", Type = FieldType.Password)]
         public string Password { get; set; }
-
-        [FieldDefinition(5, Label = "Convert to Format", Type = FieldType.Textbox, HelpText = "Optionally ask calibre to convert to other formats on import. Comma separated list.")]
         public string OutputFormat { get; set; }
-
-        [FieldDefinition(6, Label = "Conversion Profile", Type = FieldType.Select, SelectOptions = typeof(CalibreProfile), HelpText = "The output profile to use for conversion")]
         public int OutputProfile { get; set; }
-
-        [FieldDefinition(9, Label = "Use SSL", Type = FieldType.Checkbox)]
         public bool UseSsl { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Download/Clients/Hadouken/HadoukenProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Hadouken/HadoukenProxy.cs
@@ -74,7 +74,7 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
 
             var requestBuilder = new JsonRpcRequestBuilder(baseUrl, method, parameters);
             requestBuilder.LogResponseContent = true;
-            requestBuilder.NetworkCredential = new NetworkCredential(settings.Username, settings.Password);
+            requestBuilder.NetworkCredential = new BasicNetworkCredential(settings.Username, settings.Password);
             requestBuilder.Headers.Add("Accept-Encoding", "gzip,deflate");
 
             var httpRequest = requestBuilder.Build();

--- a/src/NzbDrone.Core/Download/Clients/Nzbget/NzbgetProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/NzbgetProxy.cs
@@ -229,7 +229,7 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
 
             var requestBuilder = new JsonRpcRequestBuilder(baseUrl, method, parameters);
             requestBuilder.LogResponseContent = true;
-            requestBuilder.NetworkCredential = new NetworkCredential(settings.Username, settings.Password);
+            requestBuilder.NetworkCredential = new BasicNetworkCredential(settings.Username, settings.Password);
 
             var httpRequest = requestBuilder.Build();
 

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV1.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV1.cs
@@ -261,7 +261,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             var requestBuilder = new HttpRequestBuilder(settings.UseSsl, settings.Host, settings.Port, settings.UrlBase)
             {
                 LogResponseContent = true,
-                NetworkCredential = new NetworkCredential(settings.Username, settings.Password)
+                NetworkCredential = new BasicNetworkCredential(settings.Username, settings.Password)
             };
             return requestBuilder;
         }

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -270,7 +270,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             var requestBuilder = new HttpRequestBuilder(settings.UseSsl, settings.Host, settings.Port, settings.UrlBase)
             {
                 LogResponseContent = true,
-                NetworkCredential = new NetworkCredential(settings.Username, settings.Password)
+                NetworkCredential = new BasicNetworkCredential(settings.Username, settings.Password)
             };
             return requestBuilder;
         }

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionProxy.cs
@@ -200,7 +200,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                 .Accept(HttpAccept.Json);
 
             requestBuilder.LogResponseContent = true;
-            requestBuilder.NetworkCredential = new NetworkCredential(settings.Username, settings.Password);
+            requestBuilder.NetworkCredential = new BasicNetworkCredential(settings.Username, settings.Password);
             requestBuilder.AllowAutoRedirect = false;
 
             return requestBuilder;

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentProxy.cs
@@ -4,6 +4,7 @@ using System.Net;
 using CookComputing.XmlRpc;
 using NLog;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
 
 namespace NzbDrone.Core.Download.Clients.RTorrent
 {
@@ -246,7 +247,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
 
             if (!settings.Username.IsNullOrWhiteSpace())
             {
-                client.Credentials = new NetworkCredential(settings.Username, settings.Password);
+                client.Credentials = new BasicNetworkCredential(settings.Username, settings.Password);
             }
 
             return client;

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentProxy.cs
@@ -196,7 +196,7 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
                 .Accept(HttpAccept.Json);
 
             requestBuilder.LogResponseContent = true;
-            requestBuilder.NetworkCredential = new NetworkCredential(settings.Username, settings.Password);
+            requestBuilder.NetworkCredential = new BasicNetworkCredential(settings.Username, settings.Password);
 
             return requestBuilder;
         }

--- a/src/NzbDrone.Core/HealthCheck/Checks/CalibreRootFolderCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/CalibreRootFolderCheck.cs
@@ -1,0 +1,128 @@
+using System;
+using System.IO;
+using System.Linq;
+using NLog;
+using NzbDrone.Common.Disk;
+using NzbDrone.Common.EnvironmentInfo;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Books.Calibre;
+using NzbDrone.Core.Datastore.Events;
+using NzbDrone.Core.Download.Clients;
+using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.RootFolders;
+
+namespace NzbDrone.Core.HealthCheck.Checks
+{
+    [CheckOn(typeof(ModelEvent<RootFolder>))]
+    [CheckOn(typeof(ModelEvent<RemotePathMapping>))]
+    public class CalibreRootFolderCheck : HealthCheckBase
+    {
+        private readonly IDiskProvider _diskProvider;
+        private readonly IRootFolderService _rootFolderService;
+        private readonly ICalibreProxy _calibreProxy;
+        private readonly Logger _logger;
+        private readonly IOsInfo _osInfo;
+
+        public CalibreRootFolderCheck(IDiskProvider diskProvider,
+                                      IRootFolderService rootFolderService,
+                                      ICalibreProxy calibreProxy,
+                                      IOsInfo osInfo,
+                                      Logger logger)
+        {
+            _diskProvider = diskProvider;
+            _rootFolderService = rootFolderService;
+            _calibreProxy = calibreProxy;
+            _logger = logger;
+            _osInfo = osInfo;
+        }
+
+        public override HealthCheck Check()
+        {
+            var rootFolders = _rootFolderService.All().Where(x => x.IsCalibreLibrary);
+
+            foreach (var folder in rootFolders)
+            {
+                try
+                {
+                    var calibreIsLocal = folder.CalibreSettings.Host == "127.0.0.1" || folder.CalibreSettings.Host == "localhost";
+
+                    var files = _calibreProxy.GetAllBookFilePaths(folder.CalibreSettings);
+                    if (files.Any())
+                    {
+                        var file = files.First();
+
+                        // This directory structure is forced by calibre
+                        var bookFolder = Path.GetDirectoryName(file);
+                        var authorFolder = Path.GetDirectoryName(bookFolder);
+                        var libraryFolder = Path.GetDirectoryName(authorFolder);
+
+                        var osPath = new OsPath(libraryFolder);
+
+                        if (!osPath.IsValid)
+                        {
+                            if (!calibreIsLocal)
+                            {
+                                return new HealthCheck(GetType(), HealthCheckResult.Error, $"Remote calibre for root folder {folder.Name} reports files in {libraryFolder} but this is not a valid {_osInfo.Name} path.  Review your remote path mappings and root folder settings.", "#bad-remote-path-mapping");
+                            }
+                            else if (_osInfo.IsDocker)
+                            {
+                                return new HealthCheck(GetType(), HealthCheckResult.Error, $"You are using docker; calibre for root folder {folder.Name} reports files in {libraryFolder} but this is not a valid {_osInfo.Name} path.  Review your remote path mappings and download client settings.", "#docker-bad-remote-path-mapping");
+                            }
+                            else
+                            {
+                                return new HealthCheck(GetType(), HealthCheckResult.Error, $"Local calibre server for root folder {folder.Name} reports files in {libraryFolder} but this is not a valid {_osInfo.Name} path.  Review your download client settings.", "#bad-download-client-settings");
+                            }
+                        }
+
+                        if (!_diskProvider.FolderExists(libraryFolder))
+                        {
+                            if (_osInfo.IsDocker)
+                            {
+                                return new HealthCheck(GetType(), HealthCheckResult.Error, $"You are using docker; calibre server for root folder {folder.Name} places downloads in {libraryFolder} but this directory does not appear to exist inside the container.  Review your remote path mappings and container volume settings.", "#docker-bad-remote-path-mapping");
+                            }
+                            else if (!calibreIsLocal)
+                            {
+                                return new HealthCheck(GetType(), HealthCheckResult.Error, $"Remote calibre server for root folder {folder.Name} places downloads in {libraryFolder} but this directory does not appear to exist.  Likely missing or incorrect remote path mapping.", "#bad-remote-path-mapping");
+                            }
+                            else
+                            {
+                                return new HealthCheck(GetType(), HealthCheckResult.Error, $"Calibre server for root folder {folder.Name} places downloads in {libraryFolder} but Readarr cannot see this directory.  You may need to adjust the folder's permissions or add a remote path mapping if calibre is running in docker", "#permissions-error");
+                            }
+                        }
+
+                        if (!_diskProvider.FileExists(file))
+                        {
+                            if (_osInfo.IsDocker)
+                            {
+                                return new HealthCheck(GetType(), HealthCheckResult.Error, $"You are using docker; calibre server for root folder {folder.Name} listed file {file} but this file does not appear to exist inside the container.  Review permissions for {libraryFolder} and PUID/PGID container settings", "#docker-bad-remote-path-mapping");
+                            }
+                            else if (!calibreIsLocal)
+                            {
+                                return new HealthCheck(GetType(), HealthCheckResult.Error, $"Remote calibre server for root folder {folder.Name} listed file {file} but this file does not appear to exist.  Review permissions for {libraryFolder}", "#permissions-error");
+                            }
+                            else
+                            {
+                                return new HealthCheck(GetType(), HealthCheckResult.Error, $"Calibre server for root folder {folder.Name} listed file {file} but Readarr cannot see this file.  Review permissions for {libraryFolder}", "#permissions-error");
+                            }
+                        }
+
+                        if (!libraryFolder.PathEquals(folder.Path))
+                        {
+                            return new HealthCheck(GetType(), HealthCheckResult.Error, $"Calibre for root folder {folder.Name} reports files in {libraryFolder} but this is not the same as the root folder path {folder.Path} you chose.  You may need to edit any remote path mapping or delete the root folder and re-create with the correct path", "#calibre-root-does-not-match");
+                        }
+                    }
+                }
+                catch (DownloadClientException ex)
+                {
+                    _logger.Debug(ex, "Unable to communicate with calibre server for root folder {0}", folder.Name);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error(ex, "Unknown error occured in CalibreRootFolderCheck HealthCheck");
+                }
+            }
+
+            return new HealthCheck(GetType());
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Email/EmailService.cs
+++ b/src/NzbDrone.Core/Notifications/Email/EmailService.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Net.Mail;
 using FluentValidation.Results;
 using NLog;
+using NzbDrone.Common.Http;
 
 namespace NzbDrone.Core.Notifications.Email
 {
@@ -44,11 +44,11 @@ namespace NzbDrone.Core.Notifications.Email
                 }
             }
 
-            NetworkCredential credentials = null;
+            BasicNetworkCredential credentials = null;
 
             if (!string.IsNullOrWhiteSpace(settings.Username))
             {
-                credentials = new NetworkCredential(settings.Username, settings.Password);
+                credentials = new BasicNetworkCredential(settings.Username, settings.Password);
             }
 
             try
@@ -63,7 +63,7 @@ namespace NzbDrone.Core.Notifications.Email
             }
         }
 
-        private void Send(MailMessage email, string server, int port, bool ssl, NetworkCredential credentials)
+        private void Send(MailMessage email, string server, int port, bool ssl, BasicNetworkCredential credentials)
         {
             var smtp = new SmtpClient(server, port);
             smtp.EnableSsl = ssl;

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookProxy.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Common.Serializer;
@@ -33,7 +34,7 @@ namespace NzbDrone.Core.Notifications.Webhook
 
                 if (settings.Username.IsNotNullOrWhiteSpace() || settings.Password.IsNotNullOrWhiteSpace())
                 {
-                    request.AddBasicAuthentication(settings.Username, settings.Password);
+                    request.Credentials = new BasicNetworkCredential(settings.Username, settings.Password);
                 }
 
                 _httpClient.Execute(request);

--- a/src/NzbDrone.Core/RootFolders/RootFolderRepository.cs
+++ b/src/NzbDrone.Core/RootFolders/RootFolderRepository.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Text.Json;
-using Dapper;
-using NzbDrone.Common.Extensions;
-using NzbDrone.Core.Books.Calibre;
-using NzbDrone.Core.Datastore;
+﻿using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.RootFolders
@@ -20,37 +15,6 @@ namespace NzbDrone.Core.RootFolders
         }
 
         protected override bool PublishModelEvents => true;
-
-        protected override List<RootFolder> Query(SqlBuilder builder)
-        {
-            var type = typeof(RootFolder);
-            var sql = builder.Select(type).AddSelectTemplate(type);
-
-            var results = new List<RootFolder>();
-
-            using (var conn = _database.OpenConnection())
-            using (var reader = conn.ExecuteReader(sql.RawSql, sql.Parameters))
-            {
-                var parser = reader.GetRowParser<RootFolder>(type);
-                var settingsIndex = reader.GetOrdinal(nameof(RootFolder.CalibreSettings));
-                var serializerSettings = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-
-                while (reader.Read())
-                {
-                    var body = reader.IsDBNull(settingsIndex) ? null : reader.GetString(settingsIndex);
-                    var item = parser(reader);
-
-                    if (body.IsNotNullOrWhiteSpace())
-                    {
-                        item.CalibreSettings = JsonSerializer.Deserialize<CalibreSettings>(body, serializerSettings);
-                    }
-
-                    results.Add(item);
-                }
-            }
-
-            return results;
-        }
 
         public new void Delete(int id)
         {

--- a/src/NzbDrone.Core/RootFolders/RootFolderService.cs
+++ b/src/NzbDrone.Core/RootFolders/RootFolderService.cs
@@ -2,11 +2,15 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using NLog;
 using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Books.Calibre;
+using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.Commands;
 using NzbDrone.Core.Messaging.Commands;
@@ -30,16 +34,19 @@ namespace NzbDrone.Core.RootFolders
     {
         private readonly IRootFolderRepository _rootFolderRepository;
         private readonly IDiskProvider _diskProvider;
+        private readonly ICalibreProxy _calibreProxy;
         private readonly IManageCommandQueue _commandQueueManager;
         private readonly Logger _logger;
 
         public RootFolderService(IRootFolderRepository rootFolderRepository,
+                                 ICalibreProxy calibreProxy,
                                  IDiskProvider diskProvider,
                                  IManageCommandQueue commandQueueManager,
                                  Logger logger)
         {
             _rootFolderRepository = rootFolderRepository;
             _diskProvider = diskProvider;
+            _calibreProxy = calibreProxy;
             _commandQueueManager = commandQueueManager;
             _logger = logger;
         }
@@ -90,6 +97,12 @@ namespace NzbDrone.Core.RootFolders
             if (!_diskProvider.FolderWritable(rootFolder.Path))
             {
                 throw new UnauthorizedAccessException(string.Format("Root folder path '{0}' is not writable by user '{1}'", rootFolder.Path, Environment.UserName));
+            }
+
+            if (rootFolder.IsCalibreLibrary)
+            {
+                // This will throw on failure
+                _calibreProxy.GetLibraryInfo(rootFolder.CalibreSettings);
             }
         }
 

--- a/src/NzbDrone.Core/ThingiProvider/ProviderRepository.cs
+++ b/src/NzbDrone.Core/ThingiProvider/ProviderRepository.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Dapper;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Reflection;
 using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Datastore.Converters;
 using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.ThingiProvider
@@ -12,9 +14,26 @@ namespace NzbDrone.Core.ThingiProvider
         where TProviderDefinition : ProviderDefinition,
             new()
     {
+        protected readonly JsonSerializerOptions _serializerSettings;
+
         protected ProviderRepository(IMainDatabase database, IEventAggregator eventAggregator)
             : base(database, eventAggregator)
         {
+            var serializerSettings = new JsonSerializerOptions
+            {
+                AllowTrailingCommas = true,
+                IgnoreNullValues = true,
+                PropertyNameCaseInsensitive = true,
+                DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true
+            };
+
+            serializerSettings.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, true));
+            serializerSettings.Converters.Add(new TimeSpanConverter());
+            serializerSettings.Converters.Add(new UtcConverter());
+
+            _serializerSettings = serializerSettings;
         }
 
         protected override List<TProviderDefinition> Query(SqlBuilder builder)
@@ -29,7 +48,6 @@ namespace NzbDrone.Core.ThingiProvider
             {
                 var parser = reader.GetRowParser<TProviderDefinition>(typeof(TProviderDefinition));
                 var settingsIndex = reader.GetOrdinal(nameof(ProviderDefinition.Settings));
-                var serializerSettings = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
 
                 while (reader.Read())
                 {
@@ -43,7 +61,7 @@ namespace NzbDrone.Core.ThingiProvider
                     }
                     else
                     {
-                        item.Settings = (IProviderConfig)JsonSerializer.Deserialize(body, impType, serializerSettings);
+                        item.Settings = (IProviderConfig)JsonSerializer.Deserialize(body, impType, _serializerSettings);
                     }
 
                     results.Add(item);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Digest is the default for a calibre server, so supporting means less painful setup.

Add a healthcheck to make sure calibre folder is set correctly and verify calibre connection before saving root folder.

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR
