### PR TITLE
Fixed: Root Folder Downloads check giving errors when RuTorrent is used

### DIFF
--- a/src/NzbDrone.Core/Download/DownloadClientInfo.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientInfo.cs
@@ -5,6 +5,11 @@ namespace NzbDrone.Core.Download
 {
     public class DownloadClientInfo
     {
+        public DownloadClientInfo()
+        {
+            OutputRootFolders = new List<OsPath>();
+        }
+
         public bool IsLocalhost { get; set; }
         public List<OsPath> OutputRootFolders { get; set; }
     }

--- a/src/NzbDrone.Core/HealthCheck/Checks/RemotePathMappingCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/RemotePathMappingCheck.cs
@@ -61,40 +61,37 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 {
                     var status = client.GetStatus();
                     var folders = status.OutputRootFolders;
-                    if (folders != null)
+                    foreach (var folder in folders)
                     {
-                        foreach (var folder in folders)
+                        if (!folder.IsValid)
                         {
-                            if (!folder.IsValid)
+                            if (!status.IsLocalhost)
                             {
-                                if (!status.IsLocalhost)
-                                {
-                                    return new HealthCheck(GetType(), HealthCheckResult.Error, $"Remote download client {client.Definition.Name} places downloads in {folder.FullPath} but this is not a valid {_osInfo.Name} path.  Review your remote path mappings and download client settings.", "#bad_remote_path_mapping");
-                                }
-                                else if (_osInfo.IsDocker)
-                                {
-                                    return new HealthCheck(GetType(), HealthCheckResult.Error, $"You are using docker; download client {client.Definition.Name} places downloads in {folder.FullPath} but this is not a valid {_osInfo.Name} path.  Review your remote path mappings and download client settings.", "#docker_bad_remote_path_mapping");
-                                }
-                                else
-                                {
-                                    return new HealthCheck(GetType(), HealthCheckResult.Error, $"Local download client {client.Definition.Name} places downloads in {folder.FullPath} but this is not a valid {_osInfo.Name} path.  Review your download client settings.", "#bad_download_client_settings");
-                                }
+                                return new HealthCheck(GetType(), HealthCheckResult.Error, $"Remote download client {client.Definition.Name} places downloads in {folder.FullPath} but this is not a valid {_osInfo.Name} path.  Review your remote path mappings and download client settings.", "#bad_remote_path_mapping");
                             }
-
-                            if (!_diskProvider.FolderExists(folder.FullPath))
+                            else if (_osInfo.IsDocker)
                             {
-                                if (_osInfo.IsDocker)
-                                {
-                                    return new HealthCheck(GetType(), HealthCheckResult.Error, $"You are using docker; download client {client.Definition.Name} places downloads in {folder.FullPath} but this directory does not appear to exist inside the container.  Review your remote path mappings and container volume settings.", "#docker_bad_remote_path_mapping");
-                                }
-                                else if (!status.IsLocalhost)
-                                {
-                                    return new HealthCheck(GetType(), HealthCheckResult.Error, $"Remote download client {client.Definition.Name} places downloads in {folder.FullPath} but this directory does not appear to exist.  Likely missing or incorrect remote path mapping.", "#bad_remote_path_mapping");
-                                }
-                                else
-                                {
-                                    return new HealthCheck(GetType(), HealthCheckResult.Error, $"Download client {client.Definition.Name} places downloads in {folder.FullPath} but Readarr cannot see this directory.  You may need to adjust the folder's permissions.", "#permissions_error");
-                                }
+                                return new HealthCheck(GetType(), HealthCheckResult.Error, $"You are using docker; download client {client.Definition.Name} places downloads in {folder.FullPath} but this is not a valid {_osInfo.Name} path.  Review your remote path mappings and download client settings.", "#docker_bad_remote_path_mapping");
+                            }
+                            else
+                            {
+                                return new HealthCheck(GetType(), HealthCheckResult.Error, $"Local download client {client.Definition.Name} places downloads in {folder.FullPath} but this is not a valid {_osInfo.Name} path.  Review your download client settings.", "#bad_download_client_settings");
+                            }
+                        }
+
+                        if (!_diskProvider.FolderExists(folder.FullPath))
+                        {
+                            if (_osInfo.IsDocker)
+                            {
+                                return new HealthCheck(GetType(), HealthCheckResult.Error, $"You are using docker; download client {client.Definition.Name} places downloads in {folder.FullPath} but this directory does not appear to exist inside the container.  Review your remote path mappings and container volume settings.", "#docker_bad_remote_path_mapping");
+                            }
+                            else if (!status.IsLocalhost)
+                            {
+                                return new HealthCheck(GetType(), HealthCheckResult.Error, $"Remote download client {client.Definition.Name} places downloads in {folder.FullPath} but this directory does not appear to exist.  Likely missing or incorrect remote path mapping.", "#bad_remote_path_mapping");
+                            }
+                            else
+                            {
+                                return new HealthCheck(GetType(), HealthCheckResult.Error, $"Download client {client.Definition.Name} places downloads in {folder.FullPath} but Readarr cannot see this directory.  You may need to adjust the folder's permissions.", "#permissions_error");
                             }
                         }
                     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes null reference error caused by RuTorrent not providing DownloadClientInfo
