### PR TITLE
Fixed: Real IP logging when IPv4 is mapped as IPv6

### DIFF
--- a/src/Readarr.Http/Extensions/RequestExtensions.cs
+++ b/src/Readarr.Http/Extensions/RequestExtensions.cs
@@ -156,6 +156,12 @@ namespace Readarr.Http.Extensions
             }
 
             var remoteIP = request.HttpContext.Connection.RemoteIpAddress;
+
+            if (remoteIP.IsIPv4MappedToIPv6)
+            {
+                remoteIP = remoteIP.MapToIPv4();
+            }
+
             var remoteAddress = remoteIP.ToString();
 
             // Only check if forwarded by a local network reverse proxy


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Works around dotnet's handling of IPv4 addresses being mapped to IPv6 and allows it to return an IPv4 when this is happening. 

