### PR TITLE
Fixed: failing test if exe is missing

### DIFF
--- a/src/NzbDrone.Core.Test/UpdateTests/UpdatePackageProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/UpdateTests/UpdatePackageProviderFixture.cs
@@ -33,12 +33,13 @@ namespace NzbDrone.Core.Test.UpdateTests
         }
 
         [Test]
-        [Ignore("Ignore until we actually release something on Master")]
+        [Ignore("Ignore until we actually release something on Main")]
         public void should_get_master_if_branch_doesnt_exit()
         {
             UseRealHttp();
             Subject.GetLatestUpdate("invalid_branch", new Version(0, 2)).Should().NotBeNull();
         }
+
 
         [Test]
         public void should_get_recent_updates()

--- a/src/NzbDrone.Core.Test/UpdateTests/UpdateServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/UpdateTests/UpdateServiceFixture.cs
@@ -68,6 +68,10 @@ namespace NzbDrone.Core.Test.UpdateTests
                   .Setup(c => c.FolderWritable(It.IsAny<string>()))
                   .Returns(true);
 
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(v => v.FileExists(It.Is<string>(s => s.EndsWith("Readarr.Update.exe"))))
+                  .Returns(true);
+
             _sandboxFolder = Mocker.GetMock<IAppFolderInfo>().Object.GetUpdateSandboxFolder();
         }
 
@@ -149,12 +153,27 @@ namespace NzbDrone.Core.Test.UpdateTests
         }
 
         [Test]
-        public void should_start_update_client()
+        public void should_start_update_client_if_updater_exists()
         {
             Subject.Execute(new ApplicationUpdateCommand());
 
             Mocker.GetMock<IProcessProvider>()
                 .Verify(c => c.Start(It.IsAny<string>(), It.Is<string>(s => s.StartsWith("12")), null, null, null), Times.Once());
+        }
+
+        [Test]
+        public void should_return_with_warning_if_updater_doesnt_exists()
+        {
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(v => v.FileExists(It.Is<string>(s => s.EndsWith("Readarr.Update.exe"))))
+                  .Returns(false);
+
+            Subject.Execute(new ApplicationUpdateCommand());
+
+            Mocker.GetMock<IProcessProvider>()
+                .Verify(c => c.Start(It.IsAny<string>(), It.IsAny<string>(), null, null, null), Times.Never());
+
+            ExceptionVerification.ExpectedWarns(1);
         }
 
         [Test]

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -175,7 +175,7 @@ namespace NzbDrone.Core.Configuration
 
         public bool AnalyticsEnabled => GetValueBoolean("AnalyticsEnabled", true, persist: false);
 
-        public string Branch => GetValue("Branch", "master").ToLowerInvariant();
+        public string Branch => GetValue("Branch", "main").ToLowerInvariant();
 
         public string LogLevel => GetValue("LogLevel", "info");
         public string ConsoleLogLevel => GetValue("ConsoleLogLevel", string.Empty, persist: false);

--- a/src/NzbDrone.Core/Configuration/DeploymentInfoProvider.cs
+++ b/src/NzbDrone.Core/Configuration/DeploymentInfoProvider.cs
@@ -1,10 +1,14 @@
-using System;
-using System.IO;
-using System.Text.RegularExpressions;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Update;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace NzbDrone.Core.Configuration
 {
@@ -12,6 +16,7 @@ namespace NzbDrone.Core.Configuration
     {
         string PackageVersion { get; }
         string PackageAuthor { get; }
+        string PackageGlobalMessage { get; }
         string PackageBranch { get; }
         UpdateMechanism PackageUpdateMechanism { get; }
         string PackageUpdateMechanismMessage { get; }
@@ -33,7 +38,7 @@ namespace NzbDrone.Core.Configuration
             var releaseInfoPath = Path.Combine(bin, "release_info");
 
             PackageUpdateMechanism = UpdateMechanism.BuiltIn;
-            DefaultBranch = "aphrodite";
+            DefaultBranch = "main";
 
             if (Path.GetFileName(bin) == "bin" && diskProvider.FileExists(packageInfoPath))
             {
@@ -41,6 +46,7 @@ namespace NzbDrone.Core.Configuration
 
                 PackageVersion = ReadValue(data, "PackageVersion");
                 PackageAuthor = ReadValue(data, "PackageAuthor");
+                PackageGlobalMessage = ReadValue(data, "PackageGlobalMessage");
                 PackageUpdateMechanism = ReadEnumValue(data, "UpdateMethod", UpdateMechanism.BuiltIn);
                 PackageUpdateMechanismMessage = ReadValue(data, "UpdateMethodMessage");
                 PackageBranch = ReadValue(data, "Branch");
@@ -94,6 +100,7 @@ namespace NzbDrone.Core.Configuration
 
         public string PackageVersion { get; private set; }
         public string PackageAuthor { get; private set; }
+        public string PackageGlobalMessage { get; private set; }
         public string PackageBranch { get; private set; }
         public UpdateMechanism PackageUpdateMechanism { get; private set; }
         public string PackageUpdateMechanismMessage { get; private set; }

--- a/src/NzbDrone.Core/HealthCheck/Checks/PackageGlobalMessageCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/PackageGlobalMessageCheck.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Download;
+using NzbDrone.Core.ThingiProvider.Events;
+
+namespace NzbDrone.Core.HealthCheck.Checks
+{
+    public class PackageGlobalMessageCheck : HealthCheckBase
+    {
+        private readonly IDeploymentInfoProvider _deploymentInfoProvider;
+
+
+        public PackageGlobalMessageCheck(IDeploymentInfoProvider deploymentInfoProvider)
+        {
+            _deploymentInfoProvider = deploymentInfoProvider;
+        }
+
+        public override HealthCheck Check()
+        {
+            if (_deploymentInfoProvider.PackageGlobalMessage.IsNullOrWhiteSpace())
+            {
+                return new HealthCheck(GetType());
+            }
+
+            var message = _deploymentInfoProvider.PackageGlobalMessage;
+            HealthCheckResult result = HealthCheckResult.Notice;
+            
+            if (message.StartsWith("Error:"))
+            {
+                message = message.Substring(6);
+                result = HealthCheckResult.Error;
+            }
+            else if (message.StartsWith("Warn:"))
+            {
+                message = message.Substring(5);
+                result = HealthCheckResult.Warning;
+            }
+
+            return new HealthCheck(GetType(), result, message, "#package_maintainer_message");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Update/InstallUpdateService.cs
+++ b/src/NzbDrone.Core/Update/InstallUpdateService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Threading;
 using NLog;
 using NzbDrone.Common;
 using NzbDrone.Common.Disk;
@@ -11,12 +13,14 @@ using NzbDrone.Common.Instrumentation.Extensions;
 using NzbDrone.Common.Processes;
 using NzbDrone.Core.Backup;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Lifecycle;
 using NzbDrone.Core.Messaging.Commands;
+using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Update.Commands;
 
 namespace NzbDrone.Core.Update
 {
-    public class InstallUpdateService : IExecute<ApplicationUpdateCheckCommand>, IExecute<ApplicationUpdateCommand>
+    public class InstallUpdateService : IExecute<ApplicationUpdateCommand>, IExecute<ApplicationUpdateCheckCommand>, IHandle<ApplicationStartingEvent>
     {
         private readonly ICheckUpdateService _checkUpdateService;
         private readonly Logger _logger;
@@ -33,7 +37,6 @@ namespace NzbDrone.Core.Update
         private readonly IConfigFileProvider _configFileProvider;
         private readonly IRuntimeInfo _runtimeInfo;
         private readonly IBackupService _backupService;
-        private readonly IOsInfo _osInfo;
 
         public InstallUpdateService(ICheckUpdateService checkUpdateService,
                                     IAppFolderInfo appFolderInfo,
@@ -49,14 +52,12 @@ namespace NzbDrone.Core.Update
                                     IConfigFileProvider configFileProvider,
                                     IRuntimeInfo runtimeInfo,
                                     IBackupService backupService,
-                                    IOsInfo osInfo,
                                     Logger logger)
         {
             if (configFileProvider == null)
             {
                 throw new ArgumentNullException(nameof(configFileProvider));
             }
-
             _checkUpdateService = checkUpdateService;
             _appFolderInfo = appFolderInfo;
             _commandQueueManager = commandQueueManager;
@@ -71,11 +72,10 @@ namespace NzbDrone.Core.Update
             _configFileProvider = configFileProvider;
             _runtimeInfo = runtimeInfo;
             _backupService = backupService;
-            _osInfo = osInfo;
             _logger = logger;
         }
 
-        private void InstallUpdate(UpdatePackage updatePackage)
+        private bool InstallUpdate(UpdatePackage updatePackage)
         {
             EnsureAppDataSafety();
 
@@ -93,6 +93,12 @@ namespace NzbDrone.Core.Update
                 {
                     throw new UpdateFolderNotWritableException("Cannot install update because UI folder '{0}' is not writable by the user '{1}'.", uiFolder, Environment.UserName);
                 }
+            }
+
+            if (_appFolderInfo.StartUpFolder.EndsWith("_output"))
+            {
+                _logger.ProgressDebug("Running in developer environment, not updating.");
+                return false;
             }
 
             var updateSandboxFolder = _appFolderInfo.GetUpdateSandboxFolder();
@@ -130,22 +136,26 @@ namespace NzbDrone.Core.Update
             if (OsInfo.IsNotWindows && _configFileProvider.UpdateMechanism == UpdateMechanism.Script)
             {
                 InstallUpdateWithScript(updateSandboxFolder);
-                return;
+                return true;
             }
 
             _logger.Info("Preparing client");
             _diskTransferService.TransferFolder(_appFolderInfo.GetUpdateClientFolder(), updateSandboxFolder, TransferMode.Move);
 
-            // Set executable flag on update app
-            if (OsInfo.IsOsx || (OsInfo.IsLinux && PlatformInfo.IsNetCore))
+            var updateClientExePath = _appFolderInfo.GetUpdateClientExePath();
+
+            if (!_diskProvider.FileExists(updateClientExePath))
             {
-                _diskProvider.SetFilePermissions(_appFolderInfo.GetUpdateClientExePath(updatePackage.Runtime), "755", null);
+                _logger.Warn("Update client {0} does not exist, aborting update.", updateClientExePath);
+                return false;
             }
 
-            _logger.Info("Starting update client {0}", _appFolderInfo.GetUpdateClientExePath(updatePackage.Runtime));
+            _logger.Info("Starting update client {0}", updateClientExePath);
             _logger.ProgressInfo("Readarr will restart shortly.");
 
-            _processProvider.Start(_appFolderInfo.GetUpdateClientExePath(updatePackage.Runtime), GetUpdaterArgs(updateSandboxFolder));
+            _processProvider.Start(updateClientExePath, GetUpdaterArgs(updateSandboxFolder));
+
+            return true;
         }
 
         private void EnsureValidBranch(UpdatePackage package)
@@ -192,9 +202,8 @@ namespace NzbDrone.Core.Update
         {
             var processId = _processProvider.GetCurrentProcess().Id.ToString();
             var executingApplication = _runtimeInfo.ExecutingApplication;
-            var args = string.Join(" ", processId, updateSandboxFolder.TrimEnd(Path.DirectorySeparatorChar).WrapInQuotes(), executingApplication.WrapInQuotes(), _startupContext.PreservedArguments);
-            _logger.Info("Updater Arguments: " + args);
-            return args;
+
+            return string.Join(" ", processId, updateSandboxFolder.TrimEnd(Path.DirectorySeparatorChar).WrapInQuotes(), executingApplication.WrapInQuotes(), _startupContext.PreservedArguments);
         }
 
         private void EnsureAppDataSafety()
@@ -218,17 +227,12 @@ namespace NzbDrone.Core.Update
                 return null;
             }
 
-            if (_osInfo.IsDocker)
+            if (OsInfo.IsNotWindows && !_configFileProvider.UpdateAutomatically && updateTrigger != CommandTrigger.Manual)
             {
-                _logger.ProgressDebug("Updating is disabled inside a docker container.  Please update the container image.");
+                _logger.ProgressDebug("Auto-update not enabled, not installing available update");
                 return null;
             }
 
-            if (OsInfo.IsNotWindows && !_configFileProvider.UpdateAutomatically && updateTrigger != CommandTrigger.Manual)
-            {
-                _logger.ProgressDebug("Auto-update not enabled, not installing available update.");
-                return null;
-            }
 
             // Safety net, ConfigureUpdateMechanism should take care of invalid settings
             if (_configFileProvider.UpdateMechanism == UpdateMechanism.BuiltIn && _deploymentInfoProvider.IsExternalUpdateMechanism)
@@ -279,6 +283,66 @@ namespace NzbDrone.Core.Update
                     _logger.Error(ex, "Update process failed");
                     throw new CommandFailedException(ex);
                 }
+            }
+        }
+
+        public void Handle(ApplicationStartingEvent message)
+        {
+            // Check if we have to do an application update on startup
+
+            try
+            {
+                // Don't do a prestartup update check unless BuiltIn update is enabled
+                if (_configFileProvider.UpdateAutomatically ||
+                    _configFileProvider.UpdateMechanism != UpdateMechanism.BuiltIn ||
+                    _deploymentInfoProvider.IsExternalUpdateMechanism)
+                {
+                    return;
+                }
+
+                var updateMarker = Path.Combine(_appFolderInfo.AppDataFolder, "update_required");
+                if (!_diskProvider.FileExists(updateMarker))
+                {
+                    return;
+                }
+
+                _logger.Debug("Post-install update check requested");
+
+                var latestAvailable = _checkUpdateService.AvailableUpdate();
+                if (latestAvailable == null)
+                {
+                    _logger.Debug("No post-install update available");
+                    _diskProvider.DeleteFile(updateMarker);
+                    return;
+                }
+
+
+                _logger.Info("Installing post-install update from {0} to {1}", BuildInfo.Version, latestAvailable.Version);
+                _diskProvider.DeleteFile(updateMarker);
+
+                var installing = InstallUpdate(latestAvailable);
+
+                if (installing)
+                {
+                    _logger.Debug("Install in progress, giving installer 30 seconds.");
+
+                    var watch = Stopwatch.StartNew();
+
+                    while (watch.Elapsed < TimeSpan.FromSeconds(30))
+                    {
+                        Thread.Sleep(1000);
+                    }
+
+                    _logger.Error("Post-install update not completed within 30 seconds. Attempting to continue normal operation.");
+                }
+                else
+                {
+                    _logger.Debug("Post-install update cancelled for unknown reason. Attempting to continue normal operation.");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to perform the post-install update check. Attempting to continue normal operation.");
             }
         }
     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Properly fails update test if the Readarr.Update.exe is missing.
Adds mechanism for package maintainers to produce a health check error (required for above fix).

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* Fixes #860 
* Fixes [AB#727](https://dev.azure.com/Servarr/7ab38f4e-5a57-4d70-84f4-94dd9bc5d6df/_workitems/edit/727)
* Fixes #859
* Fixes [AB#726](https://dev.azure.com/Servarr/7ab38f4e-5a57-4d70-84f4-94dd9bc5d6df/_workitems/edit/726)
* Fixes #203 