### PR TITLE
New: Add missing Part Number and Part Count Examples

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -79,9 +79,10 @@ const bookTokens = [
 
   { token: '{Book Disambiguation}', example: 'Disambiguation' },
 
-  { token: '{PartNumber}', example: '2' },
-
-  { token: '{PartCount}', example: '10' }
+  { token: '{PartNumber:0}', example: '2' },
+  { token: '{PartNumber:00}', example: '02' },
+  { token: '{PartCount:0}', example: '9' },
+  { token: '{PartCount:00}', example: '09' }
 ];
 
 const releaseDateTokens = [


### PR DESCRIPTION
#### Database Migration
NO

#### Description
add missing naming examples
- note legacy  `PartCount` and `PartNumber` act as `PartCount:0` and `PartNumber:0`

#### Screenshot (if UI related)
![image](https://user-images.githubusercontent.com/55419169/129459969-6cd630b4-e6aa-40f8-9421-3226867efd2d.png)

#### Todos
- N/A Tests
- N/A Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [X] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes Discord Discussion