### PR TITLE
Fixed: Ensure AudioTag years have default values

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/AudioTagServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/AudioTagServiceFixture.cs
@@ -17,7 +17,6 @@ using NzbDrone.Test.Common;
 namespace NzbDrone.Core.Test.MediaFiles.AudioTagServiceFixture
 {
     [TestFixture]
-    [Ignore("Readarr doesn't currently support audio")]
     public class AudioTagServiceFixture : CoreTest<AudioTagService>
     {
         public static class TestCaseFactory
@@ -362,6 +361,16 @@ namespace NzbDrone.Core.Test.MediaFiles.AudioTagServiceFixture
             var fileInfo = _diskProvider.GetFileInfo(file.Path);
             file.Modified.Should().Be(fileInfo.LastWriteTimeUtc);
             file.Size.Should().Be(fileInfo.Length);
+        }
+
+        [Test]
+        public void should_not_fail_reading_metadata_with_dates_omitted()
+        {
+            var bookFile = GivenPopulatedTrackfile(0);
+            bookFile.Edition.Value.ReleaseDate = null;
+            bookFile.Edition.Value.Book.Value.ReleaseDate = null;
+
+            Assert.DoesNotThrow(() => Subject.GetTrackMetadata(bookFile));
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/AudioTagServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/AudioTagServiceFixture.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.Test.MediaFiles.AudioTagServiceFixture
         {
             private static readonly string[] MediaFiles = new[] { "nin.mp2", "nin.mp3", "nin.flac", "nin.m4a", "nin.wma", "nin.ape", "nin.opus" };
 
-            private static readonly string[] SkipProperties = new[] { "IsValid", "Duration", "Quality", "MediaInfo", "ImageFile" };
+            private static readonly string[] SkipProperties = new[] { "IsValid", "Duration", "Quality", "MediaInfo", "ImageFile", "BookAuthors" };
             private static readonly Dictionary<string, string[]> SkipPropertiesByFile = new Dictionary<string, string[]>
             {
                 { "nin.mp2", new[] { "OriginalReleaseDate" } }
@@ -193,6 +193,9 @@ namespace NzbDrone.Core.Test.MediaFiles.AudioTagServiceFixture
             var writtentags = Subject.ReadAudioTag(path);
 
             VerifySame(writtentags, _testTags, skipProperties);
+            writtentags.BookAuthors.Should().BeEquivalentTo(
+                _testTags.BookAuthors.Concat(_testTags.Performers),
+                options => options.WithStrictOrdering());
         }
 
         [Test]
@@ -336,12 +339,12 @@ namespace NzbDrone.Core.Test.MediaFiles.AudioTagServiceFixture
         [Test]
         public void should_not_fail_if_media_has_been_omitted()
         {
-            // make sure that we aren't relying on index of items in
-            // Media being the same as the medium number
-            var file = GivenPopulatedTrackfile(100);
-            var tag = Subject.GetTrackMetadata(file);
+            GivenFileCopy("nin.mp3");
 
-            tag.Media.Should().NotBeNull();
+            var file = GivenPopulatedTrackfile(100);
+            file.Path = _copiedFile;
+
+            Assert.DoesNotThrow(() => Subject.GetTrackMetadata(file));
         }
 
         [TestCase("nin.mp3")]
@@ -366,7 +369,10 @@ namespace NzbDrone.Core.Test.MediaFiles.AudioTagServiceFixture
         [Test]
         public void should_not_fail_reading_metadata_with_dates_omitted()
         {
+            GivenFileCopy("nin.mp3");
+
             var bookFile = GivenPopulatedTrackfile(0);
+            bookFile.Path = _copiedFile;
             bookFile.Edition.Value.ReleaseDate = null;
             bookFile.Edition.Value.Book.Value.ReleaseDate = null;
 

--- a/src/NzbDrone.Core/MediaFiles/AudioTagService.cs
+++ b/src/NzbDrone.Core/MediaFiles/AudioTagService.cs
@@ -108,9 +108,9 @@ namespace NzbDrone.Core.MediaFiles
                 // We may have omitted media so index in the list isn't the same as medium number
                 Media = fileTags.Media,
                 Date = edition.ReleaseDate,
-                Year = (uint)edition.ReleaseDate?.Year,
+                Year = (uint)(edition.ReleaseDate?.Year ?? 0),
                 OriginalReleaseDate = book.ReleaseDate,
-                OriginalYear = (uint)book.ReleaseDate?.Year,
+                OriginalYear = (uint)(book.ReleaseDate?.Year ?? 0),
                 Publisher = edition.Publisher,
                 Genres = new string[0],
                 ImageFile = imageFile,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Ensure the edition and book ReleaseDate have a default value when creating AudioTags
Also enable unit tests for AudioTagService

#### Screenshot (if UI related)

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* Fixes #1253