### PR TITLE
Fixed: Audiobooks will not be attached to email notifications

### DIFF
--- a/src/NzbDrone.Core/Notifications/Email/Email.cs
+++ b/src/NzbDrone.Core/Notifications/Email/Email.cs
@@ -7,6 +7,7 @@ using MailKit.Security;
 using MimeKit;
 using NLog;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.MediaFiles;
 
 namespace NzbDrone.Core.Notifications.Email
 {
@@ -101,9 +102,16 @@ namespace NzbDrone.Core.Notifications.Email
                 builder.HtmlBody = body;
                 foreach (var url in attachmentUrls)
                 {
-                    byte[] bytes = System.IO.File.ReadAllBytes(url);
-                    builder.Attachments.Add(url, bytes);
-                    _logger.Trace("Attaching: {0}", url);
+                    if (MediaFileExtensions.AudioExtensions.Contains(System.IO.Path.GetExtension(url)))
+                    {
+                        byte[] bytes = System.IO.File.ReadAllBytes(url);
+                        builder.Attachments.Add(url, bytes);
+                        _logger.Trace("Attaching ebook file: {0}", url);
+                    }
+                    else
+                    {
+                        _logger.Trace("Skipping audiobook file: {0}", url);
+                    }
                 }
 
                 email.Body = builder.ToMessageBody();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Audiobooks will be generally too large to send as emails and shouldn't be attached to the download notifications. (Most mail services allow between 25 and 150mb maximum message size including headers) 

Bypassing audiobooks should stop a need to check the various files for size etc. on a download but should still allow most eBooks to send

#### Issues Fixed or Closed by this PR

* Fixes #1101