### PR TITLE
Fixed: Default Branch to Nightly

### DIFF
--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -175,7 +175,9 @@ namespace NzbDrone.Core.Configuration
 
         public bool AnalyticsEnabled => GetValueBoolean("AnalyticsEnabled", true, persist: false);
 
-        public string Branch => GetValue("Branch", "master").ToLowerInvariant();
+        // TODO: Change back to "develop" for the first beta release.
+        // TODO: Change back to "master" for the first stable release
+        public string Branch => GetValue("Branch", "nightly").ToLowerInvariant();
 
         public string LogLevel => GetValue("LogLevel", "info");
         public string ConsoleLogLevel => GetValue("ConsoleLogLevel", string.Empty, persist: false);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently the default branch is `master` which does not exist.
This changes the default branch to `nightly` until a `develop` is cut at which point we should swap then.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX