### PR TITLE
New: Removing rtorrent downloads when seeding criteria have been met

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentProxy.cs
@@ -18,6 +18,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
         void RemoveTorrent(string hash, RTorrentSettings settings);
         void SetTorrentLabel(string hash, string label, RTorrentSettings settings);
         bool HasHashTorrent(string hash, RTorrentSettings settings);
+        void PushTorrentUniqueView(string hash, string view, RTorrentSettings settings);
     }
 
     public interface IRTorrent : IXmlRpcProxy
@@ -45,6 +46,9 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
 
         [XmlRpcMethod("d.custom1.set")]
         string SetLabel(string hash, string label);
+
+        [XmlRpcMethod("d.views.push_back_unique")]
+        int PushUniqueView(string hash, string view);
 
         [XmlRpcMethod("system.client_version")]
         string GetVersion();
@@ -87,7 +91,8 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
                     "d.ratio=", // long
                     "d.is_open=", // long
                     "d.is_active=", // long
-                    "d.complete=")); //long
+                    "d.complete=", //long
+                    "d.timestamp.finished=")); // long (unix timestamp)
 
             var items = new List<RTorrentTorrent>();
 
@@ -107,6 +112,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
                 item.IsOpen = Convert.ToBoolean((long)torrent[8]);
                 item.IsActive = Convert.ToBoolean((long)torrent[9]);
                 item.IsFinished = Convert.ToBoolean((long)torrent[10]);
+                item.FinishedTime = (long)torrent[11];
 
                 items.Add(item);
             }
@@ -170,6 +176,18 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
             if (response != label)
             {
                 throw new DownloadClientException("Could not set label to {1} for torrent: {0}.", hash, label);
+            }
+        }
+
+        public void PushTorrentUniqueView(string hash, string view, RTorrentSettings settings)
+        {
+            _logger.Debug("Executing remote method: d.views.push_back_unique");
+
+            var client = BuildClient(settings);
+            var response = ExecuteRequest(() => client.PushUniqueView(hash, view));
+            if (response != 0)
+            {
+                throw new DownloadClientException("Could not push unique view {0} for torrent: {1}.", view, hash);
             }
         }
 

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentTorrent.cs
@@ -10,6 +10,7 @@
         public long RemainingSize { get; set; }
         public long DownRate { get; set; }
         public long Ratio { get; set; }
+        public long FinishedTime { get; set; }
         public bool IsFinished { get; set; }
         public bool IsOpen { get; set; }
         public bool IsActive { get; set; }

--- a/src/NzbDrone.Core/Download/DownloadSeedConfigProvider.cs
+++ b/src/NzbDrone.Core/Download/DownloadSeedConfigProvider.cs
@@ -1,0 +1,89 @@
+using System;
+using NLog;
+using NzbDrone.Common.Cache;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Download.Clients;
+using NzbDrone.Core.Download.History;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.Download
+{
+    public interface IDownloadSeedConfigProvider
+    {
+        TorrentSeedConfiguration GetSeedConfiguration(string infoHash);
+    }
+
+    public class DownloadSeedConfigProvider : IDownloadSeedConfigProvider
+    {
+        private readonly Logger _logger;
+        private readonly ISeedConfigProvider _indexerSeedConfigProvider;
+        private readonly IDownloadHistoryService _downloadHistoryService;
+
+        private class CachedSeedConfiguration
+        {
+            public int IndexerId { get; set; }
+            public bool Book { get; set; }
+        }
+
+        private readonly ICached<CachedSeedConfiguration> _cacheDownloads;
+
+        public DownloadSeedConfigProvider(IDownloadHistoryService downloadHistoryService, ISeedConfigProvider indexerSeedConfigProvider, ICacheManager cacheManager, Logger logger)
+        {
+            _logger = logger;
+            _indexerSeedConfigProvider = indexerSeedConfigProvider;
+            _downloadHistoryService = downloadHistoryService;
+
+            _cacheDownloads = cacheManager.GetRollingCache<CachedSeedConfiguration>(GetType(), "indexerByHash", TimeSpan.FromHours(1));
+        }
+
+        public TorrentSeedConfiguration GetSeedConfiguration(string infoHash)
+        {
+            if (infoHash.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
+
+            infoHash = infoHash.ToUpper();
+
+            var cachedConfig = _cacheDownloads.Get(infoHash, () => FetchIndexer(infoHash));
+
+            if (cachedConfig == null)
+            {
+                return null;
+            }
+
+            var seedConfig = _indexerSeedConfigProvider.GetSeedConfiguration(cachedConfig.IndexerId);
+
+            return seedConfig;
+        }
+
+        private CachedSeedConfiguration FetchIndexer(string infoHash)
+        {
+            var historyItem = _downloadHistoryService.GetLatestGrab(infoHash);
+
+            if (historyItem == null)
+            {
+                _logger.Debug("No download history item for infohash {0}, unable to provide seed configuration", infoHash);
+                return null;
+            }
+
+            ParsedBookInfo parsedBookInfo = null;
+            if (historyItem.Release != null)
+            {
+                parsedBookInfo = Parser.Parser.ParseBookTitle(historyItem.Release.Title);
+            }
+
+            if (parsedBookInfo == null)
+            {
+                _logger.Debug("No parsed title in download history item for infohash {0}, unable to provide seed configuration", infoHash);
+                return null;
+            }
+
+            return new CachedSeedConfiguration
+            {
+                IndexerId = historyItem.IndexerId,
+            };
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/SeedConfigProvider.cs
+++ b/src/NzbDrone.Core/Indexers/SeedConfigProvider.cs
@@ -1,22 +1,27 @@
 using System;
+using NzbDrone.Common.Cache;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Download.Clients;
+using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Indexers
 {
     public interface ISeedConfigProvider
     {
-        TorrentSeedConfiguration GetSeedConfiguration(RemoteBook release);
+        TorrentSeedConfiguration GetSeedConfiguration(RemoteMovie release);
+        TorrentSeedConfiguration GetSeedConfiguration(int indexerId);
     }
 
-    public class SeedConfigProvider : ISeedConfigProvider
+    public class SeedConfigProvider : ISeedConfigProvider, IHandle<IndexerSettingUpdatedEvent>
     {
         private readonly IIndexerFactory _indexerFactory;
+        private readonly ICached<SeedCriteriaSettings> _cache;
 
-        public SeedConfigProvider(IIndexerFactory indexerFactory)
+        public SeedConfigProvider(IIndexerFactory indexerFactory, ICacheManager cacheManager)
         {
             _indexerFactory = indexerFactory;
+            _cache = cacheManager.GetRollingCache<SeedCriteriaSettings>(GetType(), "criteriaByIndexer", TimeSpan.FromHours(1));
         }
 
         public TorrentSeedConfiguration GetSeedConfiguration(RemoteBook remoteBook)
@@ -31,33 +36,56 @@ namespace NzbDrone.Core.Indexers
                 return null;
             }
 
+            return GetSeedConfiguration(remoteBook.Release.IndexerId);
+        }
+
+        public TorrentSeedConfiguration GetSeedConfiguration(int indexerId)
+        {
+            if (indexerId == 0)
+            {
+                return null;
+            }
+
+            var seedCriteria = _cache.Get(indexerId.ToString(), () => FetchSeedCriteria(indexerId));
+
+            if (seedCriteria == null)
+            {
+                return null;
+            }
+
+            var seedConfig = new TorrentSeedConfiguration
+            {
+                Ratio = seedCriteria.SeedRatio
+            };
+
+            var seedTime = seedCriteria.SeedTime;
+
+            if (seedTime.HasValue)
+            {
+                seedConfig.SeedTime = TimeSpan.FromMinutes(seedTime.Value);
+            }
+
+            return seedConfig;
+        }
+
+        private SeedCriteriaSettings FetchSeedCriteria(int indexerId)
+        {
             try
             {
                 var indexer = _indexerFactory.Get(remoteBook.Release.IndexerId);
                 var torrentIndexerSettings = indexer.Settings as ITorrentIndexerSettings;
 
-                if (torrentIndexerSettings != null && torrentIndexerSettings.SeedCriteria != null)
-                {
-                    var seedConfig = new TorrentSeedConfiguration
-                    {
-                        Ratio = torrentIndexerSettings.SeedCriteria.SeedRatio
-                    };
-
-                    var seedTime = remoteBook.ParsedBookInfo.Discography ? torrentIndexerSettings.SeedCriteria.DiscographySeedTime : torrentIndexerSettings.SeedCriteria.SeedTime;
-                    if (seedTime.HasValue)
-                    {
-                        seedConfig.SeedTime = TimeSpan.FromMinutes(seedTime.Value);
-                    }
-
-                    return seedConfig;
-                }
+                return torrentIndexerSettings?.SeedCriteria;
             }
             catch (ModelNotFoundException)
             {
                 return null;
             }
+        }
 
-            return null;
+        public void Handle(IndexerSettingUpdatedEvent message)
+        {
+            _cache.Clear();
         }
     }
 }


### PR DESCRIPTION
(cherry picked from commit 411be4d0116f0739bb9c71235312d0c5a26dd3a2)

(cherry picked from commit 1c0621af0a49fb4b5db6e2f7f085bc79192ff559)

# Conflicts:
#	src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
#	src/NzbDrone.Core/Indexers/SeedConfigProvider.cs

#### Database Migration
YES - XXXX | NO

#### Description
Allows Readarr to remove torrents from rtorrent when seed goals are met per indexer. 

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes: #1035 
* Fixes: [AB#519](https://dev.azure.com/Servarr/7ab38f4e-5a57-4d70-84f4-94dd9bc5d6df/_workitems/edit/519)