### PR TITLE
Fixed: Email attachments of ebooks

### DIFF
--- a/src/NzbDrone.Core/Notifications/Email/Email.cs
+++ b/src/NzbDrone.Core/Notifications/Email/Email.cs
@@ -127,7 +127,7 @@ namespace NzbDrone.Core.Notifications.Email
                 builder.HtmlBody = body;
                 foreach (var url in attachmentUrls)
                 {
-                    if (MediaFileExtensions.AudioExtensions.Contains(System.IO.Path.GetExtension(url)))
+                    if (MediaFileExtensions.TextExtensions.Contains(System.IO.Path.GetExtension(url)))
                     {
                         byte[] bytes = System.IO.File.ReadAllBytes(url);
                         builder.Attachments.Add(url, bytes);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Email attachments were incorrectly validating that the attachment was an audiobook, and not an ebook.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
