### PR TITLE
Fixed: Correctly calculate books on Author page

### DIFF
--- a/frontend/src/Author/Index/ProgressBar/AuthorIndexProgressBar.js
+++ b/frontend/src/Author/Index/ProgressBar/AuthorIndexProgressBar.js
@@ -17,8 +17,8 @@ function AuthorIndexProgressBar(props) {
     detailedProgressBar
   } = props;
 
-  const progress = bookCount ? bookFileCount / bookCount * 100 : 100;
-  const text = `${bookFileCount} / ${bookCount}`;
+  const progress = bookCount ? bookCount / totalBookCount * 100 : 100;
+  const text = `${bookCount} / ${totalBookCount}`;
 
   return (
     <ProgressBar

--- a/frontend/src/Author/Index/Table/AuthorIndexRow.js
+++ b/frontend/src/Author/Index/Table/AuthorIndexRow.js
@@ -297,7 +297,7 @@ class AuthorIndexRow extends Component {
                     progress={progress}
                     kind={getProgressBarKind(status, monitored, progress)}
                     showText={true}
-                    text={`${bookFileCount} / ${bookCount}`}
+                    text={`${bookCount} / ${totalBookCount}`}
                     title={translate('BookFileCountBookCountTotalTotalBookCountInterp', [bookFileCount, bookCount, totalBookCount])}
                     width={125}
                   />

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "esprint": "3.1.0",
     "file-loader": "6.2.0",
     "html-webpack-plugin": "5.3.2",
-    "loader-utils": "^2.0.0",
+    "loader-utils": "^2.0.3",
     "mini-css-extract-plugin": "2.1.0",
     "postcss": "8.3.6",
     "postcss-color-function": "4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4758,10 +4758,10 @@ loader-utils@^1.4.0:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
-loader-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
-  integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
+loader-utils@^2.0.0, loader-utils@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.3.tgz#d4b15b8504c63d1fc3f2ade52d41bc8459d6ede1"
+  integrity sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The book count, particularly for audiobooks, was using file counts instead of book counts, so the progress bar was always incorrect. This fixes those counts.

For some reason, the color is not correct for book progress on the Table page. It's correct on both Overview and Poster pages. I worked on it for a bit, but the color being off wasn't a huge issue and I'd rather see the counts correct.

#### Screenshot (if UI related)
Before:
![readarr_old](https://user-images.githubusercontent.com/15488393/200338145-1cf4443f-349e-4248-ad83-858f18cf2bf5.PNG)

After:
![image](https://user-images.githubusercontent.com/15488393/200338208-3e0756d5-9da9-455e-9c6c-9f0d86eea290.png)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #1509 