### PR TITLE
Fix notifiation in Ntfy on test from Radarr to Sonarr

### DIFF
--- a/src/NzbDrone.Core/Notifications/Ntfy/NtfyProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Ntfy/NtfyProxy.cs
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.Notifications.Ntfy
         {
             try
             {
-                const string title = "Radarr - Test Notification";
+                const string title = "Readarr - Test Notification";
 
                 const string body = "This is a test message from Readarr";
 


### PR DESCRIPTION
# Conflicts:
#	src/NzbDrone.Core/Notifications/Ntfy/NtfyProxy.cs

#### Database Migration
NO

#### Description
Readarr Ntfy title line said Radarr, changed to properly read Readarr.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #2140 