### PR TITLE
fix-CreateEmptyAuthorFoldersFix create empty author folders

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -148,7 +148,7 @@ namespace NzbDrone.Core.MediaFiles
                     {
                         if (_configService.DeleteEmptyFolders)
                         {
-                            _logger.Debug("Not creating missing author folder: {0} because delete empty series folders is enabled", folder);
+                            _logger.Debug("Not creating missing author folder: {0} because delete empty author folders is enabled", folder);
                         }
                         else
                         {

--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -89,6 +89,19 @@ namespace NzbDrone.Core.MediaFiles
             {
                 authorIds = new List<int>();
             }
+            else
+            {
+                folders = new List<string>();
+                foreach (var authorId in authorIds)
+                {
+                    var author = _authorService.GetAuthor(authorId);
+
+                    if (author != null)
+                    {
+                        folders.Add(author.Path);
+                    }
+                }
+            }
 
             var mediaFileList = new List<IFileInfo>();
 


### PR DESCRIPTION
Addresses Issue [#435]
Two commits to this PR. 

Commit 1: 
Fixed: DiskScanService.cs Scan() function now utilizes the 'authorIds' variable in the function call

When a list of authorIds is passed into the DiskScanService 'Scan' function, the current code disregards the authorIds array that's passed in and scans the entire folder structure unnecessarily. When new authors are added, it should only scan their folders, not the entire root again as it takes a significant amount of time for large libraries and prevents us from being able to do Part 2 of this change coming next...
Part 2, if we correct this step will then enable us to create the missing Authors folder, resulting in a 'fixed' user interface option 'Create empty Author folders' (this currently does nothing). 
All these changes were in the DiskScanService.cs file alone. 
Updated the "public void Scan()" function so it respects the 'Author' variable being passed in and populates the folder array correctly. 

Commit 2: 
Fix: Creates Empty Author Folders if the user has turned that on in the UI

Readarr was missing the CreateEmptyAuthorFolders function which is similar to CreateEmptySeriesFolders from Sonarr. 
All these changes were in the DiskScanService.cs file alone. 
Updated the "public void Scan()" function to make it match Sonarr's mechanism for creating empty folders for authors/series.
Brought the Sonarr code over and changed "Series" references to "Author", also added the SetPermissions function that was a part of Sonarr's implementation. 

This is part 2 of a set of changes to improve scan function to scan author folders and create them if they are missing. 