### PR TITLE
Fix: Stop ImageUrl from being overwritten

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/Goodreads/Resources/BestBookResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/Goodreads/Resources/BestBookResource.cs
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.MetadataSource.Goodreads
             }
 
             ImageUrl = element.ElementAsString("image_url");
-            ImageUrl = element.ElementAsString("large_image_url");
+            LargeImageUrl = element.ElementAsString("large_image_url");
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
During debugging of the ImportLists I noticed that ImageUrl keep ending up null. 
I do not think this is intended behavior but someone with a better overview of the codebase should review this.
