### PR TITLE
Fix an issue where Readarr import lists would add all books

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Readarr/ReadarrAPIResource.cs
+++ b/src/NzbDrone.Core/ImportLists/Readarr/ReadarrAPIResource.cs
@@ -25,6 +25,7 @@ namespace NzbDrone.Core.ImportLists.Readarr
 
     public class ReadarrBook
     {
+        public int Id { get; set; }
         public string Title { get; set; }
         public string ForeignBookId { get; set; }
         public string Overview { get; set; }
@@ -32,7 +33,6 @@ namespace NzbDrone.Core.ImportLists.Readarr
         public bool Monitored { get; set; }
         public ReadarrAuthor Author { get; set; }
         public int AuthorId { get; set; }
-        public List<ReadarrEdition> Editions { get; set; }
     }
 
     public class ReadarrProfile

--- a/src/NzbDrone.Core/ImportLists/Readarr/ReadarrImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Readarr/ReadarrImport.cs
@@ -52,9 +52,8 @@ namespace NzbDrone.Core.ImportLists.Readarr
                             BookGoodreadsId = remoteBook.ForeignBookId,
                             Book = remoteBook.Title,
 
-                            // ToDo: Fix me. Edition is no longer in the book resource; rethink edition logic
-                            // Bandaid fix for now...This will cause the imported book to possibly not be same edition as the source
-                            // EditionGoodreadsId = remoteBook.Editions.Single(x => x.Monitored).ForeignEditionId,
+                            // Grab the remote Readarr's edition.
+                            EditionGoodreadsId = _readarrV1Proxy.GetEdition(Settings, remoteBook.Id).ForeignEditionId,
                             Author = remoteAuthor.AuthorName,
                             AuthorGoodreadsId = remoteAuthor.ForeignAuthorId
                         });

--- a/src/NzbDrone.Core/ImportLists/Readarr/ReadarrV1Proxy.cs
+++ b/src/NzbDrone.Core/ImportLists/Readarr/ReadarrV1Proxy.cs
@@ -15,6 +15,7 @@ namespace NzbDrone.Core.ImportLists.Readarr
         List<ReadarrBook> GetBooks(ReadarrSettings settings);
         List<ReadarrProfile> GetProfiles(ReadarrSettings settings);
         List<ReadarrTag> GetTags(ReadarrSettings settings);
+        ReadarrEdition GetEdition(ReadarrSettings settings, int bookId);
         ValidationFailure Test(ReadarrSettings settings);
     }
 
@@ -47,6 +48,11 @@ namespace NzbDrone.Core.ImportLists.Readarr
         public List<ReadarrTag> GetTags(ReadarrSettings settings)
         {
             return Execute<ReadarrTag>("/api/v1/tag", settings);
+        }
+
+        public ReadarrEdition GetEdition(ReadarrSettings settings, int bookId)
+        {
+            return Execute<ReadarrEdition>($"api/v1/edition?bookId={bookId}", settings).Find(x => x.Monitored);
         }
 
         public ValidationFailure Test(ReadarrSettings settings)


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Readarr import lists are currently broken when using `Monitor: Specific Book` with a metadata profile of `None` or equivalent (e.g., minimum popularity 10000000000).

The desired effect of these settings is to only add the books from the remote Readarr and nothing else. However, when using these settings no books are added and the following error is seen:

```
2023-04-19 05:58:08.8|Error|AddBookService|Failed to import id: 1234 - 

[v0.1.4.1596] System.InvalidOperationException: Sequence contains no matching element
   at System.Linq.ThrowHelper.ThrowNoMatchException()
   at NzbDrone.Core.Books.AddBookService.AddSkyhookData(Book newBook) in D:\a\1\s\src\NzbDrone.Core\Books\Services\AddBookService.cs:line 117
   at NzbDrone.Core.Books.AddBookService.AddBook(Book book, Boolean doRefresh) in D:\a\1\s\src\NzbDrone.Core\Books\Services\AddBookService.cs:line 45
   at NzbDrone.Core.Books.AddBookService.AddBooks(List`1 books, Boolean doRefresh) in D:\a\1\s\src\NzbDrone.Core\Books\Services\AddBookService.cs:line 92
```

Everything works when using a non-None metadata profile, but this has the undesirable effect of adding _all_ books from an author -- not just the imported ones.

The error is due to https://github.com/Readarr/Readarr/commit/a59706ceb42acbdb2128143ce027340cf0d9858e which removed editions from the payload returned by the books API. This is not a problem when using a metadata profile that grabs all books, because that also fetches editions that were previously returned by the API. When we use a profile that doesn't grab all books, however, we no longer have an edition ID to import, so when we try to monitor the book there is no prerequisite edition to operate on.

To compensate for the missing edition ID, this PR now grabs an edition ID from the remote Readarr directly. I have confirmed this works as expected.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes https://github.com/Readarr/Readarr/issues/1329 (currently impossible to do without adding all books)