### PR TITLE
Fixed: Migrations running on newer versions of SQLite

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/001_initial_setup.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/001_initial_setup.cs
@@ -327,10 +327,6 @@ namespace NzbDrone.Core.Datastore.Migration
                 .WithColumn("Label").AsString().NotNullable()
                 .WithColumn("Filters").AsString().NotNullable();
 
-            IfDatabase("sqlite").Create.Index().OnTable("Books").OnColumn("AuthorId");
-            IfDatabase("sqlite").Create.Index().OnTable("Books").OnColumn("AuthorId").Ascending()
-                .OnColumn("ReleaseDate").Ascending();
-
             Delete.Index().OnTable("History").OnColumn("BookId");
             Create.Index().OnTable("History").OnColumn("BookId").Ascending()
                                              .OnColumn("Date").Descending();

--- a/src/NzbDrone.Core/Datastore/Migration/015_fix_indexes.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/015_fix_indexes.cs
@@ -8,9 +8,6 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
-            IfDatabase("sqlite").Delete.Index().OnTable("Books").OnColumn("AuthorId");
-            IfDatabase("sqlite").Delete.Index().OnTable("Books").OnColumns("AuthorId", "ReleaseDate");
-
             Create.Index().OnTable("Editions").OnColumn("BookId");
         }
     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Removing migrations for non-existing columns which can't be executed on newer versions of SQLite.

#### Issues Fixed or Closed by this PR

* Fixes #3375