### PR TITLE
Correct replacement of german umlauts in search

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -39,6 +39,10 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
 
             //remove any repeating +s
             cleanTitle = Regex.Replace(cleanTitle, @"\+{2,}", "+");
+            cleanTitle = cleanTitle.Replace("ä", "ae");
+            cleanTitle = cleanTitle.Replace("ü", "ue");
+            cleanTitle = cleanTitle.Replace("ö", "oe");
+            cleanTitle = cleanTitle.Replace("ß", "ss");
             cleanTitle = cleanTitle.RemoveAccent();
             cleanTitle = cleanTitle.Trim('+', ' ');
 


### PR DESCRIPTION
Replace german umlauts with correct counterparts (ä => ae, etc) see #3273

#### Database Migration
NO

#### Description
SearchCriteriaBase uses RemoveAccent to strip characters from book titles and author names. German umlauts (ä, ö, ü, ß) are thus reduced to (a, o, u, s). In german it is common to replace umlauts with a combination of letters (ä => ae, ö => oe, ü => ue, ß => ss).

Without correct replacement, many german books can not be automatically grabbed and can´t be found using manual search. With this fix, german books can be managed much easier. It also seems to fix importing the files automatically after the download client finished.

I could only test this implementation with sabnzbd, can´t tell if it also works with torrents. Also, there might be issues with other languages i am not aware of. In this case it might be better to use the LocalizationService?

Additionally, this fix does not search for both possible replacements as discussed in #3273, but only the standard german replacement. Performing multiple searches might require more work.

Please let me know if you agree with this approach or if changes / additions are needed.

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #3273