### PR TITLE
Fixed: Support new states in qBittorrent 5 preventing downloads from being removed

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
@@ -178,8 +178,9 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
             VerifyWarning(item);
         }
 
-        [Test]
-        public void paused_item_should_have_required_properties()
+        [TestCase("pausedDL")]
+        [TestCase("stoppedDL")]
+        public void paused_item_should_have_required_properties(string state)
         {
             var torrent = new QBittorrentTorrent
             {
@@ -188,7 +189,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
                 Size = 1000,
                 Progress = 0.7,
                 Eta = 8640000,
-                State = "pausedDL",
+                State = state,
                 Label = "",
                 SavePath = ""
             };
@@ -200,6 +201,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
         }
 
         [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
         [TestCase("queuedUP")]
         [TestCase("uploading")]
         [TestCase("stalledUP")]
@@ -397,8 +399,9 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
             result.OutputPath.FullPath.Should().Be(Path.Combine(torrent.SavePath, "Droned.S01.12"));
         }
 
-        [Test]
-        public void api_261_should_use_content_path()
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void api_261_should_use_content_path(string state)
         {
             var torrent = new QBittorrentTorrent
             {
@@ -407,7 +410,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
                 Size = 1000,
                 Progress = 0.7,
                 Eta = 8640000,
-                State = "pausedUP",
+                State = state,
                 Label = "",
                 SavePath = @"C:\Torrents".AsOsAgnostic(),
                 ContentPath = @"C:\Torrents\Droned.S01.12".AsOsAgnostic()
@@ -684,44 +687,48 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
             item.CanMoveFiles.Should().BeFalse();
         }
 
-        [Test]
-        public void should_not_be_removable_and_should_not_allow_move_files_if_max_ratio_is_not_set()
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_not_be_removable_and_should_not_allow_move_files_if_max_ratio_is_not_set(string state)
         {
             GivenGlobalSeedLimits(-1);
-            GivenCompletedTorrent("pausedUP", ratio: 1.0f);
+            GivenCompletedTorrent(state, ratio: 1.0f);
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeFalse();
             item.CanMoveFiles.Should().BeFalse();
         }
 
-        [Test]
-        public void should_be_removable_and_should_allow_move_files_if_max_ratio_reached_and_paused()
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_be_removable_and_should_allow_move_files_if_max_ratio_reached_and_paused(string state)
         {
             GivenGlobalSeedLimits(1.0f);
-            GivenCompletedTorrent("pausedUP", ratio: 1.0f);
+            GivenCompletedTorrent(state, ratio: 1.0f);
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeTrue();
             item.CanMoveFiles.Should().BeTrue();
         }
 
-        [Test]
-        public void should_be_removable_and_should_allow_move_files_if_overridden_max_ratio_reached_and_paused()
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_be_removable_and_should_allow_move_files_if_overridden_max_ratio_reached_and_paused(string state)
         {
             GivenGlobalSeedLimits(2.0f);
-            GivenCompletedTorrent("pausedUP", ratio: 1.0f, ratioLimit: 0.8f);
+            GivenCompletedTorrent(state, ratio: 1.0f, ratioLimit: 0.8f);
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeTrue();
             item.CanMoveFiles.Should().BeTrue();
         }
 
-        [Test]
-        public void should_not_be_removable_if_overridden_max_ratio_not_reached_and_paused()
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_not_be_removable_if_overridden_max_ratio_not_reached_and_paused(string state)
         {
             GivenGlobalSeedLimits(0.2f);
-            GivenCompletedTorrent("pausedUP", ratio: 0.5f, ratioLimit: 0.8f);
+            GivenCompletedTorrent(state, ratio: 0.5f, ratioLimit: 0.8f);
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeFalse();
@@ -739,33 +746,36 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
             item.CanMoveFiles.Should().BeFalse();
         }
 
-        [Test]
-        public void should_be_removable_and_should_allow_move_files_if_max_seedingtime_reached_and_paused()
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_be_removable_and_should_allow_move_files_if_max_seedingtime_reached_and_paused(string state)
         {
             GivenGlobalSeedLimits(-1, 20);
-            GivenCompletedTorrent("pausedUP", ratio: 2.0f, seedingTime: 20);
+            GivenCompletedTorrent(state, ratio: 2.0f, seedingTime: 20);
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeTrue();
             item.CanMoveFiles.Should().BeTrue();
         }
 
-        [Test]
-        public void should_be_removable_and_should_allow_move_files_if_overridden_max_seedingtime_reached_and_paused()
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_be_removable_and_should_allow_move_files_if_overridden_max_seedingtime_reached_and_paused(string state)
         {
             GivenGlobalSeedLimits(-1, 40);
-            GivenCompletedTorrent("pausedUP", ratio: 2.0f, seedingTime: 20, seedingTimeLimit: 10);
+            GivenCompletedTorrent(state, ratio: 2.0f, seedingTime: 20, seedingTimeLimit: 10);
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeTrue();
             item.CanMoveFiles.Should().BeTrue();
         }
 
-        [Test]
-        public void should_not_be_removable_if_overridden_max_seedingtime_not_reached_and_paused()
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_not_be_removable_if_overridden_max_seedingtime_not_reached_and_paused(string state)
         {
             GivenGlobalSeedLimits(-1, 20);
-            GivenCompletedTorrent("pausedUP", ratio: 2.0f, seedingTime: 30, seedingTimeLimit: 40);
+            GivenCompletedTorrent(state, ratio: 2.0f, seedingTime: 30, seedingTimeLimit: 40);
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeFalse();
@@ -783,66 +793,72 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
             item.CanMoveFiles.Should().BeFalse();
         }
 
-        [Test]
-        public void should_be_removable_and_should_allow_move_files_if_max_inactive_seedingtime_reached_and_paused()
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_be_removable_and_should_allow_move_files_if_max_inactive_seedingtime_reached_and_paused(string state)
         {
             GivenGlobalSeedLimits(-1, maxInactiveSeedingTime: 20);
-            GivenCompletedTorrent("pausedUP", ratio: 2.0f, lastActivity: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMinutes(25)).ToUnixTimeSeconds());
+            GivenCompletedTorrent(state, ratio: 2.0f, lastActivity: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMinutes(25)).ToUnixTimeSeconds());
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeTrue();
             item.CanMoveFiles.Should().BeTrue();
         }
 
-        [Test]
-        public void should_be_removable_and_should_allow_move_files_if_overridden_max_inactive_seedingtime_reached_and_paused()
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_be_removable_and_should_allow_move_files_if_overridden_max_inactive_seedingtime_reached_and_paused(string state)
         {
             GivenGlobalSeedLimits(-1, maxInactiveSeedingTime: 40);
-            GivenCompletedTorrent("pausedUP", ratio: 2.0f, seedingTime: 20, inactiveSeedingTimeLimit: 10, lastActivity: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMinutes(15)).ToUnixTimeSeconds());
+            GivenCompletedTorrent(state, ratio: 2.0f, seedingTime: 20, inactiveSeedingTimeLimit: 10, lastActivity: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMinutes(15)).ToUnixTimeSeconds());
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeTrue();
             item.CanMoveFiles.Should().BeTrue();
         }
 
-        [Test]
-        public void should_not_be_removable_if_overridden_max_inactive_seedingtime_not_reached_and_paused()
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_not_be_removable_if_overridden_max_inactive_seedingtime_not_reached_and_paused(string state)
         {
             GivenGlobalSeedLimits(-1, maxInactiveSeedingTime: 20);
-            GivenCompletedTorrent("pausedUP", ratio: 2.0f, seedingTime: 30, inactiveSeedingTimeLimit: 40, lastActivity: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMinutes(30)).ToUnixTimeSeconds());
+            GivenCompletedTorrent(state, ratio: 2.0f, seedingTime: 30, inactiveSeedingTimeLimit: 40, lastActivity: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMinutes(30)).ToUnixTimeSeconds());
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeFalse();
             item.CanMoveFiles.Should().BeFalse();
         }
 
-        [Test]
-        public void should_be_removable_and_should_allow_move_files_if_max_seedingtime_reached_but_ratio_not_and_paused()
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_be_removable_and_should_allow_move_files_if_max_seedingtime_reached_but_ratio_not_and_paused(string state)
         {
             GivenGlobalSeedLimits(2.0f, 20);
-            GivenCompletedTorrent("pausedUP", ratio: 1.0f, seedingTime: 30);
+            GivenCompletedTorrent(state, ratio: 1.0f, seedingTime: 30);
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeTrue();
             item.CanMoveFiles.Should().BeTrue();
         }
 
-        [Test]
-        public void should_be_removable_and_should_allow_move_files_if_max_inactive_seedingtime_reached_but_ratio_not_and_paused()
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_be_removable_and_should_allow_move_files_if_max_inactive_seedingtime_reached_but_ratio_not_and_paused(string state)
         {
             GivenGlobalSeedLimits(2.0f, maxInactiveSeedingTime: 20);
-            GivenCompletedTorrent("pausedUP", ratio: 1.0f, lastActivity: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMinutes(25)).ToUnixTimeSeconds());
+            GivenCompletedTorrent(state, ratio: 1.0f, lastActivity: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMinutes(25)).ToUnixTimeSeconds());
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeTrue();
             item.CanMoveFiles.Should().BeTrue();
         }
 
-        [Test]
-        public void should_not_fetch_details_twice()
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_not_fetch_details_twice(string state)
         {
             GivenGlobalSeedLimits(-1, 30);
-            GivenCompletedTorrent("pausedUP", ratio: 2.0f, seedingTime: 20);
+            GivenCompletedTorrent(state, ratio: 2.0f, seedingTime: 20);
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeFalse();
@@ -854,8 +870,9 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
                   .Verify(p => p.GetTorrentProperties(It.IsAny<string>(), It.IsAny<QBittorrentSettings>()), Times.Once());
         }
 
-        [Test]
-        public void should_get_category_from_the_category_if_set()
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_get_category_from_the_category_if_set(string state)
         {
             const string category = "music-readarr";
             GivenGlobalSeedLimits(1.0f);
@@ -867,7 +884,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
                 Size = 1000,
                 Progress = 1.0,
                 Eta = 8640000,
-                State = "pausedUP",
+                State = state,
                 Category = category,
                 SavePath = "",
                 Ratio = 1.0f
@@ -879,8 +896,9 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
             item.Category.Should().Be(category);
         }
 
-        [Test]
-        public void should_get_category_from_the_label_if_the_category_is_not_available()
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_get_category_from_the_label_if_the_category_is_not_available(string state)
         {
             const string category = "music-readarr";
             GivenGlobalSeedLimits(1.0f);
@@ -892,7 +910,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
                 Size = 1000,
                 Progress = 1.0,
                 Eta = 8640000,
-                State = "pausedUP",
+                State = state,
                 Label = category,
                 SavePath = "",
                 Ratio = 1.0f

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -239,7 +239,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
                 // Avoid removing torrents that haven't reached the global max ratio.
                 // Removal also requires the torrent to be paused, in case a higher max ratio was set on the torrent itself (which is not exposed by the api).
-                item.CanMoveFiles = item.CanBeRemoved = torrent.State == "pausedUP" && HasReachedSeedLimit(torrent, config);
+                item.CanMoveFiles = item.CanBeRemoved = torrent.State is "pausedUP" or "stoppedUP" && HasReachedSeedLimit(torrent, config);
 
                 switch (torrent.State)
                 {
@@ -248,7 +248,8 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                         item.Message = "qBittorrent is reporting an error";
                         break;
 
-                    case "pausedDL": // torrent is paused and has NOT finished downloading
+                    case "stoppedDL": // torrent is stopped and has NOT finished downloading
+                    case "pausedDL": // torrent is paused and has NOT finished downloading (qBittorrent < 5)
                         item.Status = DownloadItemStatus.Paused;
                         break;
 
@@ -259,7 +260,8 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                         item.Status = DownloadItemStatus.Queued;
                         break;
 
-                    case "pausedUP": // torrent is paused and has finished downloading
+                    case "pausedUP": // torrent is paused and has finished downloading (qBittorent < 5)
+                    case "stoppedUP": // torrent is stopped and has finished downloading
                     case "uploading": // torrent is being seeded and data is being transferred
                     case "stalledUP": // torrent is being seeded, but no connection were made
                     case "queuedUP": // queuing is enabled and torrent is queued for upload

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxySelector.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxySelector.cs
@@ -26,8 +26,6 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         Dictionary<string, QBittorrentLabel> GetLabels(QBittorrentSettings settings);
         void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfiguration, QBittorrentSettings settings);
         void MoveTorrentToTopInQueue(string hash, QBittorrentSettings settings);
-        void PauseTorrent(string hash, QBittorrentSettings settings);
-        void ResumeTorrent(string hash, QBittorrentSettings settings);
         void SetForceStart(string hash, bool enabled, QBittorrentSettings settings);
     }
 

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV1.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV1.cs
@@ -148,7 +148,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             {
                 request.AddFormParameter("paused", false);
             }
-            else if ((QBittorrentState)settings.InitialState == QBittorrentState.Pause)
+            else if ((QBittorrentState)settings.InitialState == QBittorrentState.Stop)
             {
                 request.AddFormParameter("paused", true);
             }
@@ -178,7 +178,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             {
                 request.AddFormParameter("paused", false);
             }
-            else if ((QBittorrentState)settings.InitialState == QBittorrentState.Pause)
+            else if ((QBittorrentState)settings.InitialState == QBittorrentState.Stop)
             {
                 request.AddFormParameter("paused", true);
             }
@@ -214,7 +214,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             catch (DownloadClientException ex)
             {
                 // if setCategory fails due to method not being found, then try older setLabel command for qBittorrent < v.3.3.5
-                if (ex.InnerException is HttpException && (ex.InnerException as HttpException).Response.StatusCode == HttpStatusCode.NotFound)
+                if (ex.InnerException is HttpException httpException && httpException.Response.StatusCode == HttpStatusCode.NotFound)
                 {
                     var setLabelRequest = BuildRequest(settings).Resource("/command/setLabel")
                                                                 .Post()
@@ -257,29 +257,13 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             catch (DownloadClientException ex)
             {
                 // qBittorrent rejects all Prio commands with 403: Forbidden if Options -> BitTorrent -> Torrent Queueing is not enabled
-                if (ex.InnerException is HttpException && (ex.InnerException as HttpException).Response.StatusCode == HttpStatusCode.Forbidden)
+                if (ex.InnerException is HttpException httpException && httpException.Response.StatusCode == HttpStatusCode.Forbidden)
                 {
                     return;
                 }
 
                 throw;
             }
-        }
-
-        public void PauseTorrent(string hash, QBittorrentSettings settings)
-        {
-            var request = BuildRequest(settings).Resource("/command/pause")
-                                                .Post()
-                                                .AddFormParameter("hash", hash);
-            ProcessRequest(request, settings);
-        }
-
-        public void ResumeTorrent(string hash, QBittorrentSettings settings)
-        {
-            var request = BuildRequest(settings).Resource("/command/resume")
-                                                .Post()
-                                                .AddFormParameter("hash", hash);
-            ProcessRequest(request, settings);
         }
 
         public void SetForceStart(string hash, bool enabled, QBittorrentSettings settings)

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -246,14 +246,20 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 request.AddFormParameter("category", settings.MusicCategory);
             }
 
-            // Note: ForceStart is handled by separate api call
-            if ((QBittorrentState)settings.InitialState == QBittorrentState.Start)
+            // Avoid extraneous API version check if initial state is ForceStart
+            if ((QBittorrentState)settings.InitialState is QBittorrentState.Start or QBittorrentState.Stop)
             {
-                request.AddFormParameter("paused", false);
-            }
-            else if ((QBittorrentState)settings.InitialState == QBittorrentState.Pause)
-            {
-                request.AddFormParameter("paused", true);
+                var stoppedParameterName = GetApiVersion(settings) >= new Version(2, 11, 0) ? "stopped" : "paused";
+
+                // Note: ForceStart is handled by separate api call
+                if ((QBittorrentState)settings.InitialState == QBittorrentState.Start)
+                {
+                    request.AddFormParameter(stoppedParameterName, false);
+                }
+                else if ((QBittorrentState)settings.InitialState == QBittorrentState.Stop)
+                {
+                    request.AddFormParameter(stoppedParameterName, true);
+                }
             }
 
             if (settings.SequentialOrder)
@@ -291,7 +297,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             catch (DownloadClientException ex)
             {
                 // setShareLimits was added in api v2.0.1 so catch it case of the unlikely event that someone has api v2.0
-                if (ex.InnerException is HttpException && (ex.InnerException as HttpException).Response.StatusCode == HttpStatusCode.NotFound)
+                if (ex.InnerException is HttpException httpException && httpException.Response.StatusCode == HttpStatusCode.NotFound)
                 {
                     return;
                 }
@@ -313,29 +319,13 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             catch (DownloadClientException ex)
             {
                 // qBittorrent rejects all Prio commands with 409: Conflict if Options -> BitTorrent -> Torrent Queueing is not enabled
-                if (ex.InnerException is HttpException && (ex.InnerException as HttpException).Response.StatusCode == HttpStatusCode.Conflict)
+                if (ex.InnerException is HttpException httpException && httpException.Response.StatusCode == HttpStatusCode.Conflict)
                 {
                     return;
                 }
 
                 throw;
             }
-        }
-
-        public void PauseTorrent(string hash, QBittorrentSettings settings)
-        {
-            var request = BuildRequest(settings).Resource("/api/v2/torrents/pause")
-                                                .Post()
-                                                .AddFormParameter("hashes", hash);
-            ProcessRequest(request, settings);
-        }
-
-        public void ResumeTorrent(string hash, QBittorrentSettings settings)
-        {
-            var request = BuildRequest(settings).Resource("/api/v2/torrents/resume")
-                                                .Post()
-                                                .AddFormParameter("hashes", hash);
-            ProcessRequest(request, settings);
         }
 
         public void SetForceStart(string hash, bool enabled, QBittorrentSettings settings)

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentState.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentState.cs
@@ -1,9 +1,16 @@
+using NzbDrone.Core.Annotations;
+
 namespace NzbDrone.Core.Download.Clients.QBittorrent
 {
     public enum QBittorrentState
     {
+        [FieldOption(Label = "Started")]
         Start = 0,
+
+        [FieldOption(Label = "Force Started")]
         ForceStart = 1,
-        Pause = 2
+
+        [FieldOption(Label = "Stopped")]
+        Stop = 2
     }
 }


### PR DESCRIPTION
Database Migration
NO
Description

Fixes Readarr no longer being able to complete downloads in QBittorrent 5 and therefore not being able to add books to Calibre.

Issue and cause identified [here](https://www.reddit.com/r/sonarr/comments/1fvg31u/solved_issues_with_qbittorrent_500_not_importing/)

This has been fixed in Sonarr and Radarr, but the qBitTorrent file was not cleanly applicable from these projects, so I manually added and expanded the test cases.

Fixes #3777
Closes https://github.com/Readarr/Readarr/issues/3819
Closes https://github.com/Readarr/Readarr/issues/3463