### PR TITLE
feat: allow new Calibre KEPUB convert format

### DIFF
--- a/frontend/src/Settings/MediaManagement/RootFolder/EditRootFolderModalContent.js
+++ b/frontend/src/Settings/MediaManagement/RootFolder/EditRootFolderModalContent.js
@@ -355,7 +355,7 @@ function EditRootFolderModalContent(props) {
                               />
                             }
                             title={translate('CalibreOutputFormat')}
-                            body={'Specify the output format.  Options are: MOBI, EPUB, AZW3, DOCX, FB2, HTMLZ, LIT, LRF, PDB, PDF, PMLZ, RB, RTF, SNB, TCR, TXT, TXTZ, ZIP'}
+                            body={'Specify the output format.  Options are: MOBI, EPUB, AZW3, DOCX, FB2, HTMLZ, KEPUB, LIT, LRF, PDB, PDF, PMLZ, RB, RTF, SNB, TCR, TXT, TXTZ, ZIP'}
                             position={tooltipPositions.RIGHT}
                           />
                         </FormLabel>

--- a/src/NzbDrone.Core/Books/Calibre/Resources/CalibreConversionOptions.cs
+++ b/src/NzbDrone.Core/Books/Calibre/Resources/CalibreConversionOptions.cs
@@ -11,6 +11,7 @@ namespace NzbDrone.Core.Books.Calibre
         DOCX,
         FB2,
         HTMLZ,
+        KEPUB,
         LIT,
         LRF,
         PDB,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
[Since Calibre 8.0](https://calibre-ebook.com/new-in/seventeen), converting to KEPUB format works out of the box. We should allow for this as an option in the "Convert to Format" setting for Calibre.

#### Screenshot (if UI related)
![Screenshot 2025-05-27 at 4 58 00 PM](https://github.com/user-attachments/assets/0540c57c-f8cb-4b61-9c14-486f309310de)
![Screenshot 2025-05-27 at 4 58 12 PM](https://github.com/user-attachments/assets/3b6f9424-6cd7-40b8-8a09-62ee099da3ef)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #1243 
* Completes #2372 