### PR TITLE
FIX: Fix Large Images in Author Add Modal Smushing Text Right

### DIFF
--- a/frontend/src/Search/Author/AddNewAuthorModalContent.css
+++ b/frontend/src/Search/Author/AddNewAuthorModalContent.css
@@ -8,9 +8,19 @@
 }
 
 .poster {
-  flex: 0 0 170px;
+  max-width: 370px;
+  max-height: 250px;
   margin-right: 20px;
-  height: 250px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.poster img {
+  width: 100%;
+  height: auto;
+  object-fit: contain;
 }
 
 .info {

--- a/frontend/src/Search/Author/AddNewAuthorModalContent.css
+++ b/frontend/src/Search/Author/AddNewAuthorModalContent.css
@@ -8,13 +8,13 @@
 }
 
 .poster {
-  max-width: 370px;
-  max-height: 250px;
-  margin-right: 20px;
-  flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
+  margin-right: 20px;
+  max-width: 370px;
+  max-height: 250px;
 }
 
 .poster img {


### PR DESCRIPTION

#### Description
Per the issue, if using a larger img, it would smush all of the options/text to the right making it impossible to view properly. Changed up the CSS to allow larger images to be viewable but not let them make the modal unusable.

As you can see by the second image normal sized images are not effected by the changes and should function as normal.

* Fixes #1519

#### Screenshot (if UI related)
![Showcase](https://github.com/user-attachments/assets/f8f3a4d5-c010-4080-98fc-ae7144a3620c)

![NormalAuthor](https://github.com/user-attachments/assets/69454891-6384-4866-9531-5037bf8f8f34)



