### PR TITLE
Pull Sonarr commit 'Used ReflectionOnly and/or public types where possible to avoid loading related assemblies unnecessarily.'

### DIFF
--- a/src/NzbDrone.Common/Reflection/ReflectionExtensions.cs
+++ b/src/NzbDrone.Common/Reflection/ReflectionExtensions.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Common.Reflection
 
         public static List<Type> ImplementationsOf<T>(this Assembly assembly)
         {
-            return assembly.GetTypes().Where(c => typeof(T).IsAssignableFrom(c)).ToList();
+            return assembly.GetExportedTypes().Where(c => typeof(T).IsAssignableFrom(c)).ToList();
         }
 
         public static bool IsSimpleType(this Type type)
@@ -68,7 +68,7 @@ namespace NzbDrone.Common.Reflection
 
         public static Type FindTypeByName(this Assembly assembly, string name)
         {
-            return assembly.GetTypes().SingleOrDefault(c => c.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+            return assembly.GetExportedTypes().SingleOrDefault(c => c.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
         }
 
         public static bool HasAttribute<TAttribute>(this Type type)

--- a/src/NzbDrone.Core/Datastore/DbFactory.cs
+++ b/src/NzbDrone.Core/Datastore/DbFactory.cs
@@ -40,6 +40,7 @@ namespace NzbDrone.Core.Datastore
             Environment.SetEnvironmentVariable("No_Expand", "true");
             Environment.SetEnvironmentVariable("No_SQLiteXmlConfigFile", "true");
             Environment.SetEnvironmentVariable("No_PreLoadSQLite", "true");
+            Environment.SetEnvironmentVariable("No_SQLiteFunctions", "true");
         }
 
         public DbFactory(IMigrationController migrationController,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Pull commit: Used ReflectionOnly and/or public types where possible to avoid loading related assemblies unnecessarily.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #318